### PR TITLE
Fix lldp_syncd crash upon failure to unpack chassis_attributes

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -194,7 +194,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
             rem_desc = rem_attributes.get('descr')
         except (KeyError, ValueError):
             logger.exception("Could not infer system information from: {}".format(chassis_attributes))
-            chassis_id_subtype, chassis_id, rem_name, rem_desc = None
+            chassis_id_subtype = chassis_id = rem_name = rem_desc = None
 
         return {
             # lldpRemChassisIdSubtype   LldpChassisIdSubtype,


### PR DESCRIPTION
Fixes the following:

If `parse_chassis()` failed to unpack `chassis_attributes`, the following crash would occur:

```
ERROR: Could not infer system information from: {u'id': {u'type': u'mac', u'value': u'34:17:eb:0d:aa:80'}, u'ttl': u'120'}#012Traceback (most recent call last):#012  File "/usr/local/lib/python2.7/dist-packages/lldp_syncd/daemon.py", line 191, in parse_chassis#012    (rem_name, rem_attributes), = chassis_attributes.items()#012ValueError: too many values to unpack
Exception in thread LldpSyncDaemon:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/local/lib/python2.7/dist-packages/sonic_syncd/interface.py", line 45, in run
    parsed_update = self.parse_update(update_obj)
  File "/usr/local/lib/python2.7/dist-packages/lldp_syncd/daemon.py", line 180, in parse_update
    parsed_interfaces[if_name].update(self.parse_chassis(if_attributes['chassis']))
  File "/usr/local/lib/python2.7/dist-packages/lldp_syncd/daemon.py", line 197, in parse_chassis
    chassis_id_subtype, chassis_id, rem_name, rem_desc = None
TypeError: 'NoneType' object is not iterable
```