### PR TITLE
[lldp_syncd] add new OIDs - lldpRemTable & lldpLocPortTable

### DIFF
--- a/src/lldp_syncd/__init__.py
+++ b/src/lldp_syncd/__init__.py
@@ -5,3 +5,4 @@ logger.setLevel(logging.INFO)
 logger.addHandler(logging.NullHandler())
 
 from .daemon import LldpSyncDaemon
+from .dbsyncd import DBSyncDaemon

--- a/src/lldp_syncd/dbsyncd.py
+++ b/src/lldp_syncd/dbsyncd.py
@@ -1,0 +1,56 @@
+import subprocess
+from swsssdk import ConfigDBConnector
+
+from sonic_syncd import SonicSyncDaemon
+from . import logger
+
+
+class DBSyncDaemon(SonicSyncDaemon):
+    """
+    A Thread that listens to changes in CONFIG DB,
+    and contains handlers to configure lldpd accordingly.
+    """
+
+    def __init__(self):
+        super(DBSyncDaemon, self).__init__()
+        self.config_db = ConfigDBConnector()
+        self.config_db.connect()
+        logger.info("[lldp dbsyncd] Connected to configdb")
+        self.port_table = {}
+
+    def run_command(self, command):
+        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        stdout = p.communicate()[0]
+        p.wait()
+        if p.returncode != 0:
+            logger.error('[lldp dbsyncd] command execution returned {}. \
+            Command: "{}", stdout: "{}"'.format(p.returncode, command, stdout))
+
+    def port_handler(self, key, data):
+        """
+        Handle updates in 'PORT' table.
+        """
+        # we're interested only in description for now
+        if self.port_table[key].get("description") != data.get("description"):
+            new_descr = data.get("description", "")
+            logger.info("[lldp dbsyncd] Port {} description changed to {}."
+                        .format(key, new_descr))
+            self.run_command("lldpcli configure lldp portidsubtype local {} \
+                              description '{}'".format(key, new_descr))
+        # update local cache
+        self.port_table[key] = data
+
+    def run(self):
+        self.port_table = self.config_db.get_table('PORT')
+        # supply LLDP_LOC_ENTRY_TABLE and lldpd with correct values on start
+        for port_name, attributes in self.port_table.items():
+            self.run_command("lldpcli configure lldp portidsubtype local \
+                {} description '{}'".format(
+                port_name, attributes.get("description", " ")))
+
+        # subscribe for further changes
+        self.config_db.subscribe('PORT', lambda table, key, data:
+                                 self.port_handler(key, data))
+
+        logger.info("[lldp dbsyncd] Subscribed to configdb PORT table")
+        self.config_db.listen()

--- a/src/lldp_syncd/dbsyncd.py
+++ b/src/lldp_syncd/dbsyncd.py
@@ -23,8 +23,8 @@ class DBSyncDaemon(SonicSyncDaemon):
         stdout = p.communicate()[0]
         p.wait()
         if p.returncode != 0:
-            logger.error('[lldp dbsyncd] command execution returned {}. \
-            Command: "{}", stdout: "{}"'.format(p.returncode, command, stdout))
+            logger.error("[lldp dbsyncd] command execution returned {}. "
+                         "Command: '{}', stdout: '{}'".format(p.returncode, command, stdout))
 
     def port_handler(self, key, data):
         """
@@ -32,11 +32,11 @@ class DBSyncDaemon(SonicSyncDaemon):
         """
         # we're interested only in description for now
         if self.port_table[key].get("description") != data.get("description"):
-            new_descr = data.get("description", "")
+            new_descr = data.get("description", " ")
             logger.info("[lldp dbsyncd] Port {} description changed to {}."
                         .format(key, new_descr))
-            self.run_command("lldpcli configure lldp portidsubtype local {} \
-                              description '{}'".format(key, new_descr))
+            self.run_command("lldpcli configure lldp portidsubtype local {} description '{}'"
+                             .format(key, new_descr))
         # update local cache
         self.port_table[key] = data
 
@@ -44,9 +44,8 @@ class DBSyncDaemon(SonicSyncDaemon):
         self.port_table = self.config_db.get_table('PORT')
         # supply LLDP_LOC_ENTRY_TABLE and lldpd with correct values on start
         for port_name, attributes in self.port_table.items():
-            self.run_command("lldpcli configure lldp portidsubtype local \
-                {} description '{}'".format(
-                port_name, attributes.get("description", " ")))
+            self.run_command("lldpcli configure lldp portidsubtype local {} description '{}'"
+                             .format(port_name, attributes.get("description", " ")))
 
         # subscribe for further changes
         self.config_db.subscribe('PORT', lambda table, key, data:

--- a/src/lldp_syncd/main.py
+++ b/src/lldp_syncd/main.py
@@ -1,5 +1,6 @@
 from . import logger
 from .daemon import LldpSyncDaemon
+from .dbsyncd import DBSyncDaemon
 
 DEFAULT_UPDATE_FREQUENCY = 10
 
@@ -8,8 +9,11 @@ def main(update_frequency=None):
     try:
         lldp_syncd = LldpSyncDaemon(update_frequency or DEFAULT_UPDATE_FREQUENCY)
         logger.info('Starting SONiC LLDP sync daemon...')
+        dbsyncd = DBSyncDaemon()
         lldp_syncd.start()
+        dbsyncd.start()
         lldp_syncd.join()
+        dbsyncd.join()
     except KeyboardInterrupt:
         logger.info("ctrl-C captured, shutting down.")
     except Exception:

--- a/tests/mock_tables/LLDP_ENTRY_TABLE.json
+++ b/tests/mock_tables/LLDP_ENTRY_TABLE.json
@@ -1,5 +1,8 @@
 {
   "LLDP_ENTRY_TABLE:Ethernet100": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -10,6 +13,9 @@
     "lldp_rem_port_id": "Ethernet26"
   },
   "LLDP_ENTRY_TABLE:Ethernet4": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -20,6 +26,9 @@
     "lldp_rem_port_id": "Ethernet2"
   },
   "LLDP_ENTRY_TABLE:Ethernet104": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -30,6 +39,9 @@
     "lldp_rem_port_id": "Ethernet27"
   },
   "LLDP_ENTRY_TABLE:Ethernet0": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -40,6 +52,9 @@
     "lldp_rem_port_id": "Ethernet1"
   },
   "LLDP_ENTRY_TABLE:Ethernet108": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -50,6 +65,9 @@
     "lldp_rem_port_id": "Ethernet28"
   },
   "LLDP_ENTRY_TABLE:Ethernet8": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -60,6 +78,9 @@
     "lldp_rem_port_id": "Ethernet3"
   },
   "LLDP_ENTRY_TABLE:Ethernet96": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -70,6 +91,9 @@
     "lldp_rem_port_id": "Ethernet25"
   },
   "LLDP_ENTRY_TABLE:Ethernet92": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -80,6 +104,9 @@
     "lldp_rem_port_id": "Ethernet24"
   },
   "LLDP_ENTRY_TABLE:Ethernet124": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -90,6 +117,9 @@
     "lldp_rem_port_id": "Ethernet32"
   },
   "LLDP_ENTRY_TABLE:Ethernet120": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -100,6 +130,9 @@
     "lldp_rem_port_id": "Ethernet31"
   },
   "LLDP_ENTRY_TABLE:Ethernet40": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -110,6 +143,9 @@
     "lldp_rem_port_id": "Ethernet11"
   },
   "LLDP_ENTRY_TABLE:Ethernet44": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -120,6 +156,9 @@
     "lldp_rem_port_id": "Ethernet12"
   },
   "LLDP_ENTRY_TABLE:Ethernet48": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -130,6 +169,9 @@
     "lldp_rem_port_id": "Ethernet13"
   },
   "LLDP_ENTRY_TABLE:Ethernet24": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -140,6 +182,9 @@
     "lldp_rem_port_id": "Ethernet7"
   },
   "LLDP_ENTRY_TABLE:Ethernet68": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -150,6 +195,9 @@
     "lldp_rem_port_id": "Ethernet18"
   },
   "LLDP_ENTRY_TABLE:eth0": {
+    "lldp_rem_index": 2,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm going to need you to come in on saturday",
@@ -160,6 +208,9 @@
     "lldp_rem_port_id": "ge-0/0/17"
   },
   "LLDP_ENTRY_TABLE:Ethernet20": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -170,6 +221,9 @@
     "lldp_rem_port_id": "Ethernet6"
   },
   "LLDP_ENTRY_TABLE:Ethernet60": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -180,6 +234,9 @@
     "lldp_rem_port_id": "Ethernet16"
   },
   "LLDP_ENTRY_TABLE:Ethernet64": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -190,6 +247,9 @@
     "lldp_rem_port_id": "Ethernet17"
   },
   "LLDP_ENTRY_TABLE:Ethernet112": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -200,6 +260,9 @@
     "lldp_rem_port_id": "Ethernet29"
   },
   "LLDP_ENTRY_TABLE:Ethernet116": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -210,6 +273,9 @@
     "lldp_rem_port_id": "Ethernet30"
   },
   "LLDP_ENTRY_TABLE:Ethernet84": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -220,6 +286,9 @@
     "lldp_rem_port_id": "Ethernet22"
   },
   "LLDP_ENTRY_TABLE:Ethernet80": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -230,6 +299,9 @@
     "lldp_rem_port_id": "Ethernet21"
   },
   "LLDP_ENTRY_TABLE:Ethernet88": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -240,6 +312,9 @@
     "lldp_rem_port_id": "Ethernet23"
   },
   "LLDP_ENTRY_TABLE:Ethernet52": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -250,6 +325,9 @@
     "lldp_rem_port_id": "Ethernet14"
   },
   "LLDP_ENTRY_TABLE:Ethernet76": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -260,6 +338,9 @@
     "lldp_rem_port_id": "Ethernet20"
   },
   "LLDP_ENTRY_TABLE:Ethernet56": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -270,6 +351,9 @@
     "lldp_rem_port_id": "Ethernet15"
   },
   "LLDP_ENTRY_TABLE:Ethernet72": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -280,6 +364,9 @@
     "lldp_rem_port_id": "Ethernet19"
   },
   "LLDP_ENTRY_TABLE:Ethernet32": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -290,6 +377,9 @@
     "lldp_rem_port_id": "Ethernet9"
   },
   "LLDP_ENTRY_TABLE:Ethernet28": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -300,6 +390,9 @@
     "lldp_rem_port_id": "Ethernet8"
   },
   "LLDP_ENTRY_TABLE:Ethernet36": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -310,6 +403,9 @@
     "lldp_rem_port_id": "Ethernet10"
   },
   "LLDP_ENTRY_TABLE:Ethernet16": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
@@ -320,6 +416,9 @@
     "lldp_rem_port_id": "Ethernet5"
   },
   "LLDP_ENTRY_TABLE:Ethernet12": {
+    "lldp_rem_index": 1,
+    "lldp_rem_sys_cap_enabled": "28 00",
+    "lldp_rem_sys_cap_supported": "28 00",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",

--- a/tests/mock_tables/LLDP_ENTRY_TABLE.json
+++ b/tests/mock_tables/LLDP_ENTRY_TABLE.json
@@ -33,7 +33,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18544,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet27"
@@ -59,7 +59,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18544,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet28"
@@ -72,7 +72,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet3"
@@ -85,7 +85,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "",
     "lldp_rem_port_id": "Ethernet25"
@@ -98,7 +98,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 32,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet24"
@@ -111,7 +111,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 4834,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet32"
@@ -124,7 +124,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 3844,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet31"
@@ -137,7 +137,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 572,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet11"
@@ -150,7 +150,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1202,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet12"
@@ -163,7 +163,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1202,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet13"
@@ -176,7 +176,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1775,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet7"
@@ -189,7 +189,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet18"
@@ -215,7 +215,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18545,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet6"
@@ -228,7 +228,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet16"
@@ -241,7 +241,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet17"
@@ -254,7 +254,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 2103,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet29"
@@ -267,7 +267,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1113,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet30"
@@ -280,7 +280,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 362,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet22"
@@ -293,7 +293,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 362,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet21"
@@ -306,7 +306,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 92,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet23"
@@ -319,7 +319,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet14"
@@ -332,7 +332,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet20"
@@ -345,7 +345,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet15"
@@ -358,7 +358,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet19"
@@ -371,7 +371,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1142,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet9"
@@ -384,7 +384,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18513,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet8"
@@ -397,7 +397,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 152,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet10"
@@ -410,7 +410,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18545,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet5"
@@ -423,7 +423,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18545,
-   "lldp_rem_port_desc": "",
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet4"

--- a/tests/mock_tables/LLDP_ENTRY_TABLE.json
+++ b/tests/mock_tables/LLDP_ENTRY_TABLE.json
@@ -7,7 +7,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18544,
-    "lldp_rem_port_desc": null,
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet26"
@@ -20,7 +20,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+    "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet2"
@@ -33,7 +33,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18544,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet27"
@@ -59,7 +59,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18544,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet28"
@@ -72,22 +72,22 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet3"
   },
   "LLDP_ENTRY_TABLE:Ethernet96": {
     "lldp_rem_index": 1,
-    "lldp_rem_sys_cap_enabled": "28 00",
-    "lldp_rem_sys_cap_supported": "28 00",
+    "lldp_rem_sys_cap_enabled": null,
+    "lldp_rem_sys_cap_supported": null,
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
-    "lldp_rem_sys_desc": "I'm a little teapot.",
+    "lldp_rem_sys_desc": "",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
-    "lldp_rem_sys_name": "switch13",
+    "lldp_rem_sys_name": "",
     "lldp_rem_port_id": "Ethernet25"
   },
   "LLDP_ENTRY_TABLE:Ethernet92": {
@@ -98,7 +98,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 32,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet24"
@@ -111,7 +111,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 4834,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet32"
@@ -124,7 +124,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 3844,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet31"
@@ -137,7 +137,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 572,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet11"
@@ -150,7 +150,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1202,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet12"
@@ -163,7 +163,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1202,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet13"
@@ -176,7 +176,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1775,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet7"
@@ -189,7 +189,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet18"
@@ -215,7 +215,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18545,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet6"
@@ -228,7 +228,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet16"
@@ -241,7 +241,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet17"
@@ -254,7 +254,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 2103,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet29"
@@ -267,7 +267,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1113,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet30"
@@ -280,7 +280,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 362,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet22"
@@ -293,7 +293,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 362,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet21"
@@ -306,7 +306,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 92,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet23"
@@ -319,7 +319,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet14"
@@ -332,7 +332,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet20"
@@ -345,7 +345,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet15"
@@ -358,7 +358,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18543,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet19"
@@ -371,7 +371,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 1142,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet9"
@@ -384,7 +384,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18513,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet8"
@@ -397,7 +397,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 152,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet10"
@@ -410,7 +410,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18545,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet5"
@@ -423,7 +423,7 @@
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "I'm a little teapot.",
     "lldp_rem_time_mark": 18545,
-    "lldp_rem_port_desc": null,
+   "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet4"

--- a/tests/mock_tables/LLDP_ENTRY_TABLE.json
+++ b/tests/mock_tables/LLDP_ENTRY_TABLE.json
@@ -79,8 +79,8 @@
   },
   "LLDP_ENTRY_TABLE:Ethernet96": {
     "lldp_rem_index": 1,
-    "lldp_rem_sys_cap_enabled": null,
-    "lldp_rem_sys_cap_supported": null,
+    "lldp_rem_sys_cap_enabled": "",
+    "lldp_rem_sys_cap_supported": "",
     "lldp_rem_port_id_subtype": 5,
     "lldp_rem_chassis_id": "00:11:22:33:44:55",
     "lldp_rem_sys_desc": "",

--- a/tests/subproc_outputs/lldpctl.json
+++ b/tests/subproc_outputs/lldpctl.json
@@ -1,4 +1,40 @@
 {
+  "lldp_loc_chassis":{
+    "local-chassis": {
+      "chassis": {
+        "arc-switch1025": {
+          "mgmt-ip": [
+            "10.1.0.32",
+            "fc00:1::32"
+          ],
+          "id": {
+            "type": "mac",
+            "value": "7c:fe:90:63:f4:66"
+          },
+          "capability": [
+            {
+              "type": "Bridge",
+              "enabled": true
+            },
+            {
+              "type": "Router",
+              "enabled": true
+            },
+            {
+              "type": "Wlan",
+              "enabled": false
+            },
+            {
+              "type": "Station",
+              "enabled": false
+            }
+          ],
+          "descr": "Debian GNU/Linux 8 (jessie) Linux 3.16.0-5-amd64 #1 SMP Debian 3.16.51-3+deb8u1 (2018-01-08) x86_64",
+          "ttl": "120"
+        }
+      }
+    }
+  },
   "lldp": {
     "interface": [
       {
@@ -1313,25 +1349,11 @@
           },
           "via": "LLDP",
           "chassis": {
-            "switch13": {
-              "mgmt-ip": "10.3.147.196",
-              "id": {
-                "type": "mac",
-                "value": "00:11:22:33:44:55"
-              },
-              "ttl": "120",
-              "descr": "I'm a little teapot.",
-              "capability": [
-                {
-                  "type": "Bridge",
-                  "enabled": true
-                },
-                {
-                  "type": "Router",
-                  "enabled": true
-                }
-              ]
-            }
+            "id": {
+              "type": "mac",
+              "value": "00:11:22:33:44:55"
+            },
+            "ttl": "120"
           },
           "age": "0 day, 05:09:03",
           "vlan": {

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -96,16 +96,16 @@ class TestLldpSyncDaemonDBSync(TestCase):
         with mock.patch.object(lldp_syncd.DBSyncDaemon, "__init__", lambda _: None):
             self.daemon = lldp_syncd.DBSyncDaemon()
             self.daemon.port_table = {"Ethernet0":
-                {'description': "Hedgehog", "speed":50000},
+                {'description': "Hedgehog", "speed": 50000},
                 "Ethernet4":
-                {'description': "Red door'", "speed":50000}}
+                {'description': "Red door'", "speed": 50000}}
 
     def test_port_handler_descr(self):
         """
         test handling update of description of port
         """
         with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
-            self.daemon.port_handler("Ethernet4", {"description": "black door", "speed":50000})
+            self.daemon.port_handler("Ethernet4", {"description": "black door", "speed": 50000})
             self.daemon.run_command.assert_called_once_with(
                 "lldpcli configure lldp portidsubtype local Ethernet4 description 'black door'")
 
@@ -122,6 +122,6 @@ class TestLldpSyncDaemonDBSync(TestCase):
         test handling update when description field is removed
         """
         with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
-            self.daemon.port_handler("Ethernet4", {"speed":50000})
+            self.daemon.port_handler("Ethernet4", {"speed": 50000})
             self.daemon.run_command.assert_called_once_with(
-                "lldpcli configure lldp portidsubtype local Ethernet4 description ''")
+                "lldpcli configure lldp portidsubtype local Ethernet4 description ' '")

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -9,11 +9,13 @@ sys.path.insert(0, os.path.join(modules_path, 'src'))
 
 from unittest import TestCase
 import json
+import mock
 import re
 import lldp_syncd
 import lldp_syncd.conventions
 import lldp_syncd.daemon
-from swsssdk import SonicV2Connector
+import lldp_syncd.dbsyncd
+from swsssdk import SonicV2Connector, ConfigDBConnector
 
 INPUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'subproc_outputs')
 
@@ -86,3 +88,40 @@ class TestLldpSyncDaemon(TestCase):
     def test_timeparse(self):
         self.assertEquals(lldp_syncd.daemon.parse_time("0 day, 05:09:02"), make_seconds(0, 5, 9, 2))
         self.assertEquals(lldp_syncd.daemon.parse_time("2 days, 05:59:02"), make_seconds(2, 5, 59, 2))
+
+
+class TestLldpSyncDaemonDBSync(TestCase):
+    
+    def setUp(self):
+        with mock.patch.object(lldp_syncd.DBSyncDaemon, "__init__", lambda _: None):
+            self.daemon = lldp_syncd.DBSyncDaemon()
+            self.daemon.port_table = {"Ethernet0":
+                {'description': "Hedgehog", "speed":50000},
+                "Ethernet4":
+                {'description': "Red door'", "speed":50000}}
+
+    def test_port_handler_descr(self):
+        """
+        test handling update of description of port
+        """
+        with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
+            self.daemon.port_handler("Ethernet4", {"description": "black door", "speed":50000})
+            self.daemon.run_command.assert_called_once_with(
+                "lldpcli configure lldp portidsubtype local Ethernet4 description 'black door'")
+
+    def test_port_handler_speed(self):
+        """
+        test updating port speed(no action expected)
+        """
+        with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
+            self.daemon.port_handler("Ethernet0", {"speed": 100000, "description": "Hedgehog"})
+            self.daemon.run_command.assert_not_called()
+
+    def test_port_handler_delete_descr(self):
+        """
+        test handling update when description field is removed
+        """
+        with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
+            self.daemon.port_handler("Ethernet4", {"speed":50000})
+            self.daemon.run_command.assert_called_once_with(
+                "lldpcli configure lldp portidsubtype local Ethernet4 description ''")


### PR DESCRIPTION
What I did:
Add support for lldpLocPortTable and lldpRemTable OIDs:

Also requires merge of https://github.com/Azure/sonic-snmpagent/pull/70

OID | SNMP counter | Description
-- | -- | --
1.0.8802.1.1.2.1.3.7 | lldpLocPortTable |  
1.0.8802.1.1.2.1.3.7.1 | lldpLocPortEntry |  
1.0.8802.1.1.2.1.3.7.1.1 | lldpLocPortNum | The index value used to identify the port component (contained in the local chassis with the LLDP agent) associated with this entry
1.0.8802.1.1.2.1.3.7.1.2 | lldpLocPortIdSubtype | The type of port identifier encoding used in the associated 'lldpLocPortId' object
1.0.8802.1.1.2.1.3.7.1.4 | lldpLocPortDesc | The string value used to identify the 802 LAN station's port description associated with the local system. If the local agent supports IETF RFC 2863, lldpLocPortDesc object should have the same value of ifDescr object

OID | SNMP counter | Description
-- | -- | --
1.0.8802.1.1.2.1.4.1 | lldpRemTable |  
1.0.8802.1.1.2.1.4.1.1 | lldpRemEntry |  
1.0.8802.1.1.2.1.4.1.1.2 | lldpRemLocalPortNum | The index value used to identify the port component associated with this entry. The lldpRemLocalPortNum identifies the port on which the remote system information is received
1.0.8802.1.1.2.1.4.1.1.3 | lldpRemIndex | This object represents an arbitrary local integer value used by this agent to identify a particular connection instance, unique only for the indicated remote system
1.0.8802.1.1.2.1.4.1.1.11 | lldpRemSysCapSupported | The bitmap value used to identify which system capabilities are supported on the remote system
1.0.8802.1.1.2.1.4.1.1.12 | lldpRemSysCapEnabled | The bitmap value used to identify which system capabilities are enabled


