### PR TITLE
[lldp] add lldpRemManAddrTable, lldpLocManAddrTable

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -262,9 +262,19 @@ class LldpSyncDaemon(SonicSyncDaemon):
                                         'lldp_loc_sys_name',
                                         'lldp_loc_sys_desc',
                                         'lldp_loc_man_addr')
-                    parsed_chassis = zip(loc_chassis_keys,
+                    parsed_chassis = dict(zip(loc_chassis_keys,
                                          self.parse_chassis(lldp_json['lldp_loc_chassis']
-                                                            ['local-chassis']['chassis']))
+                                                            ['local-chassis']['chassis'])))
+
+                    loc_capabilities = self.get_sys_capability_list(lldp_json['lldp_loc_chassis']
+                                                                    ['local-chassis'])
+                    # lldpLocSysCapSupported
+                    parsed_chassis.update({'lldp_loc_sys_cap_supported':
+                                          self.parse_sys_capabilities(loc_capabilities)})
+                    # lldpLocSysCapEnabled
+                    parsed_chassis.update({'lldp_loc_sys_cap_enabled':
+                                          self.parse_sys_capabilities(loc_capabilities, enabled=True)})
+
                     parsed_interfaces['local-chassis'].update(parsed_chassis)
 
             return parsed_interfaces

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -251,7 +251,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
                 capability_list = self.get_sys_capability_list(if_attributes)
                 # lldpSysCapSupported
                 parsed_interfaces[if_name].update({'lldp_rem_sys_cap_supported':
-                                                    self.parse_sys_capabilities(capability_list)})
+                                                   self.parse_sys_capabilities(capability_list)})
                 # lldpSysCapEnabled
                 parsed_interfaces[if_name].update({'lldp_rem_sys_cap_enabled':
                                                    self.parse_sys_capabilities(

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -16,7 +16,7 @@ LLDPD_TIME_FORMAT = '%H:%M:%S'
 
 DEFAULT_UPDATE_INTERVAL = 10
 
-SONIC_ETHERNET_RE_PATTERN = r'^Ethernet(\d+)$'
+SONIC_ETHERNET_RE_PATTERN = r'^(Ethernet(\d+)|eth0)$'
 LLDPD_UPTIME_RE_SPLIT_PATTERN = r' days?, '
 
 
@@ -358,7 +358,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
         # Repopulate LLDP_ENTRY_TABLE by adding all changed elements
         for interface in changed + new:
             if re.match(SONIC_ETHERNET_RE_PATTERN, interface) is None:
-                logger.debug("Ignoring interface '{}'".format(interface))
+                logger.warning("Ignoring interface '{}'".format(interface))
                 continue
             # port_table_key = LLDP_ENTRY_TABLE:INTERFACE_NAME;
             table_key = ':'.join([LldpSyncDaemon.LLDP_ENTRY_TABLE, interface])

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -235,7 +235,8 @@ class LldpSyncDaemon(SonicSyncDaemon):
                     rem_chassis_keys = ('lldp_rem_chassis_id_subtype',
                                         'lldp_rem_chassis_id',
                                         'lldp_rem_sys_name',
-                                        'lldp_rem_sys_desc')
+                                        'lldp_rem_sys_desc',
+                                        'lldp_rem_man_addr')
                     parsed_chassis = zip(rem_chassis_keys,
                                          self.parse_chassis(if_attributes['chassis']))
                     parsed_interfaces[if_name].update(parsed_chassis)
@@ -259,7 +260,8 @@ class LldpSyncDaemon(SonicSyncDaemon):
                     loc_chassis_keys = ('lldp_loc_chassis_id_subtype',
                                         'lldp_loc_chassis_id',
                                         'lldp_loc_sys_name',
-                                        'lldp_loc_sys_desc')
+                                        'lldp_loc_sys_desc',
+                                        'lldp_loc_man_addr')
                     parsed_chassis = zip(loc_chassis_keys,
                                          self.parse_chassis(lldp_json['lldp_loc_chassis']
                                                             ['local-chassis']['chassis']))
@@ -282,15 +284,17 @@ class LldpSyncDaemon(SonicSyncDaemon):
             chassis_id_subtype = str(self.ChassisIdSubtypeMap[id_attributes['type']].value)
             chassis_id = id_attributes.get('value', '')
             descr = attributes.get('descr', '')
+            mgmt_ip = attributes.get('mgmt-ip', '')
         except (KeyError, ValueError):
             logger.exception("Could not infer system information from: {}"
                              .format(chassis_attributes))
-            chassis_id_subtype = chassis_id = sys_name = descr = ''
+            chassis_id_subtype = chassis_id = sys_name = descr = mgmt_ip = ''
 
         return (chassis_id_subtype,
                 chassis_id,
                 sys_name,
                 descr,
+                mgmt_ip,
                 )
 
     def parse_port(self, port_attributes):

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -16,9 +16,8 @@ LLDPD_TIME_FORMAT = '%H:%M:%S'
 
 DEFAULT_UPDATE_INTERVAL = 10
 
-SONIC_ETHERNET_RE_PATTERN = r'^(Ethernet(\d+)|eth0)$'
+SONIC_ETHERNET_RE_PATTERN = r'^Ethernet(\d+)$'
 LLDPD_UPTIME_RE_SPLIT_PATTERN = r' days?, '
-MANAGEMENT_PORT_NAME = 'eth0'
 
 
 def parse_time(time_str):
@@ -145,7 +144,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
                 if (not enabled) or capability["enabled"]:
                     sys_cap |= 128 >> LldpSystemCapabilitiesMap[capability["type"].lower()]
             except KeyError:
-                logger.warning("Unknown capability {}".format(capability["type"]))
+                logger.debug("Unknown capability {}".format(capability["type"]))
         return "%0.2X 00" % sys_cap
 
     def __init__(self, update_interval=None):
@@ -359,7 +358,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
         # Repopulate LLDP_ENTRY_TABLE by adding all changed elements
         for interface in changed + new:
             if re.match(SONIC_ETHERNET_RE_PATTERN, interface) is None:
-                logger.warning("Ignoring interface '{}'".format(interface))
+                logger.debug("Ignoring interface '{}'".format(interface))
                 continue
             # port_table_key = LLDP_ENTRY_TABLE:INTERFACE_NAME;
             table_key = ':'.join([LldpSyncDaemon.LLDP_ENTRY_TABLE, interface])

--- a/src/lldp_syncd/dbsyncd.py
+++ b/src/lldp_syncd/dbsyncd.py
@@ -1,8 +1,12 @@
 import subprocess
+import re
 from swsssdk import ConfigDBConnector
 
 from sonic_syncd import SonicSyncDaemon
 from . import logger
+
+MGMT_INTERFACE_PATTERN = r"MGMT_INTERFACE*"
+IPV4_PATTERN = r'^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$'
 
 
 class DBSyncDaemon(SonicSyncDaemon):
@@ -17,6 +21,7 @@ class DBSyncDaemon(SonicSyncDaemon):
         self.config_db.connect()
         logger.info("[lldp dbsyncd] Connected to configdb")
         self.port_table = {}
+        self.man_addr = None
 
     def run_command(self, command):
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
@@ -40,16 +45,36 @@ class DBSyncDaemon(SonicSyncDaemon):
         # update local cache
         self.port_table[key] = data
 
-    def run(self):
+    def man_addr_init(self):
+
+        man_table = self.config_db.get_table('MGMT_INTERFACE')
+        # example table:
+        # {('eth0', 'FC00:2::32/64'): {'forced_mgmt_routes': ['10.0.0.100/31'], 'gwaddr': 'fc00:2::fe'},
+        # ('eth0', '10.224.23.69/24'): {'gwaddr': '10.224.23.254'}}
+        mgmt_ips = [i[1].split('/')[0] for i in man_table.keys()]
+        ipv4_mgmt_ips = [i for i in mgmt_ips if re.match(IPV4_PATTERN, i)]
+        try:
+            self.run_command("lldpcli configure system ip management pattern {}"
+                             .format(ipv4_mgmt_ips[0]))
+            logger.debug("Configured lldpd with {} local management ip".format(ipv4_mgmt_ips[0]))
+        except IndexError:
+            logger.error("No IPv4 management interface found")
+
+    def port_table_init(self):
         self.port_table = self.config_db.get_table('PORT')
         # supply LLDP_LOC_ENTRY_TABLE and lldpd with correct values on start
         for port_name, attributes in self.port_table.items():
             self.run_command("lldpcli configure lldp portidsubtype local {} description '{}'"
                              .format(port_name, attributes.get("description", " ")))
 
+    def run(self):
+
+        self.port_table_init()
         # subscribe for further changes
         self.config_db.subscribe('PORT', lambda table, key, data:
                                  self.port_handler(key, data))
+
+        self.man_addr_init()
 
         logger.info("[lldp dbsyncd] Subscribed to configdb PORT table")
         self.config_db.listen()

--- a/tests/mock_tables/LLDP_ENTRY_TABLE.json
+++ b/tests/mock_tables/LLDP_ENTRY_TABLE.json
@@ -10,7 +10,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet26"
+    "lldp_rem_port_id": "Ethernet26",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet4": {
     "lldp_rem_index": 1,
@@ -23,7 +24,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet2"
+    "lldp_rem_port_id": "Ethernet2",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet104": {
     "lldp_rem_index": 1,
@@ -36,7 +38,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet27"
+    "lldp_rem_port_id": "Ethernet27",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet0": {
     "lldp_rem_index": 1,
@@ -49,7 +52,8 @@
     "lldp_rem_port_desc": "this is a port description",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet1"
+    "lldp_rem_port_id": "Ethernet1",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet108": {
     "lldp_rem_index": 1,
@@ -62,7 +66,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet28"
+    "lldp_rem_port_id": "Ethernet28",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet8": {
     "lldp_rem_index": 1,
@@ -75,7 +80,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet3"
+    "lldp_rem_port_id": "Ethernet3",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet96": {
     "lldp_rem_index": 1,
@@ -88,7 +94,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "",
-    "lldp_rem_port_id": "Ethernet25"
+    "lldp_rem_port_id": "Ethernet25",
+    "lldp_rem_man_addr": ""
   },
   "LLDP_ENTRY_TABLE:Ethernet92": {
     "lldp_rem_index": 1,
@@ -101,7 +108,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet24"
+    "lldp_rem_port_id": "Ethernet24",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet124": {
     "lldp_rem_index": 1,
@@ -114,7 +122,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet32"
+    "lldp_rem_port_id": "Ethernet32",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet120": {
     "lldp_rem_index": 1,
@@ -127,7 +136,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet31"
+    "lldp_rem_port_id": "Ethernet31",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet40": {
     "lldp_rem_index": 1,
@@ -140,7 +150,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet11"
+    "lldp_rem_port_id": "Ethernet11",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet44": {
     "lldp_rem_index": 1,
@@ -153,7 +164,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet12"
+    "lldp_rem_port_id": "Ethernet12",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet48": {
     "lldp_rem_index": 1,
@@ -166,7 +178,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet13"
+    "lldp_rem_port_id": "Ethernet13",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet24": {
     "lldp_rem_index": 1,
@@ -179,7 +192,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet7"
+    "lldp_rem_port_id": "Ethernet7",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet68": {
     "lldp_rem_index": 1,
@@ -192,7 +206,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet18"
+    "lldp_rem_port_id": "Ethernet18",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:eth0": {
     "lldp_rem_index": 2,
@@ -205,7 +220,8 @@
     "lldp_rem_port_desc": "TPS report vending machine",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch218ad08",
-    "lldp_rem_port_id": "ge-0/0/17"
+    "lldp_rem_port_id": "ge-0/0/17",
+    "lldp_rem_man_addr": ""
   },
   "LLDP_ENTRY_TABLE:Ethernet20": {
     "lldp_rem_index": 1,
@@ -218,7 +234,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet6"
+    "lldp_rem_port_id": "Ethernet6",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet60": {
     "lldp_rem_index": 1,
@@ -231,7 +248,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet16"
+    "lldp_rem_port_id": "Ethernet16",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet64": {
     "lldp_rem_index": 1,
@@ -244,7 +262,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet17"
+    "lldp_rem_port_id": "Ethernet17",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet112": {
     "lldp_rem_index": 1,
@@ -257,7 +276,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet29"
+    "lldp_rem_port_id": "Ethernet29",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet116": {
     "lldp_rem_index": 1,
@@ -270,7 +290,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet30"
+    "lldp_rem_port_id": "Ethernet30",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet84": {
     "lldp_rem_index": 1,
@@ -283,7 +304,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet22"
+    "lldp_rem_port_id": "Ethernet22",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet80": {
     "lldp_rem_index": 1,
@@ -296,7 +318,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet21"
+    "lldp_rem_port_id": "Ethernet21",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet88": {
     "lldp_rem_index": 1,
@@ -309,7 +332,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet23"
+    "lldp_rem_port_id": "Ethernet23",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet52": {
     "lldp_rem_index": 1,
@@ -322,7 +346,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet14"
+    "lldp_rem_port_id": "Ethernet14",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet76": {
     "lldp_rem_index": 1,
@@ -335,7 +360,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet20"
+    "lldp_rem_port_id": "Ethernet20",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet56": {
     "lldp_rem_index": 1,
@@ -348,7 +374,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet15"
+    "lldp_rem_port_id": "Ethernet15",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet72": {
     "lldp_rem_index": 1,
@@ -361,7 +388,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet19"
+    "lldp_rem_port_id": "Ethernet19",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet32": {
     "lldp_rem_index": 1,
@@ -374,7 +402,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet9"
+    "lldp_rem_port_id": "Ethernet9",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet28": {
     "lldp_rem_index": 1,
@@ -387,7 +416,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet8"
+    "lldp_rem_port_id": "Ethernet8",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet36": {
     "lldp_rem_index": 1,
@@ -400,7 +430,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet10"
+    "lldp_rem_port_id": "Ethernet10",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet16": {
     "lldp_rem_index": 1,
@@ -413,7 +444,8 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet5"
+    "lldp_rem_port_id": "Ethernet5",
+    "lldp_rem_man_addr": "10.3.147.196"
   },
   "LLDP_ENTRY_TABLE:Ethernet12": {
     "lldp_rem_index": 1,
@@ -426,6 +458,7 @@
     "lldp_rem_port_desc": "",
     "lldp_rem_chassis_id_subtype": 4,
     "lldp_rem_sys_name": "switch13",
-    "lldp_rem_port_id": "Ethernet4"
+    "lldp_rem_port_id": "Ethernet4",
+    "lldp_rem_man_addr": "10.3.147.196"
   }
 }

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -15,6 +15,22 @@ def config_set(self, *args):
     pass
 
 
+class MockPubSub:
+    def get_message(self):
+        return None
+
+    def psubscribe(self, *args, **kwargs):
+        pass
+
+    def punsubscribe(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def listen(self):
+        return []
+
 INPUT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -22,12 +38,45 @@ class SwssSyncClient(mockredis.MockRedis):
     def __init__(self, *args, **kwargs):
         super(SwssSyncClient, self).__init__(strict=True, *args, **kwargs)
         db = kwargs.pop('db')
+
+        self.pubsub = MockPubSub()
+
         if db == 0:
             with open(INPUT_DIR + '/LLDP_ENTRY_TABLE.json') as f:
                 db = json.load(f)
                 for h, table in db.items():
                     for k, v in table.items():
                         self.hset(h, k, v)
+
+        elif db == 4:
+            with open(INPUT_DIR + '/CONFIG_DB.json') as f:
+                db = json.load(f)
+                for h, table in db.items():
+                    for k, v in table.items():
+                        self.hset(h, k, v)
+
+    # Patch mockredis/mockredis/client.py
+    # The official implementation will filter out keys with a slash '/'
+    # ref: https://github.com/locationlabs/mockredis/blob/master/mockredis/client.py
+    def keys(self, pattern='*'):
+        """Emulate keys."""
+        import fnmatch
+        import re
+
+        # making sure the pattern is unicode/str.
+        try:
+            pattern = pattern.decode('utf-8')
+            # This throws an AttributeError in python 3, or an
+            # UnicodeEncodeError in python 2
+        except (AttributeError, UnicodeEncodeError):
+            pass
+
+        # Make regex out of glob styled pattern.
+        regex = fnmatch.translate(pattern)
+        regex = re.compile(regex)
+
+        # Find every key that matches the pattern
+        return [key for key in self.redis.keys() if regex.match(key.decode('utf-8'))]
 
 
 swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification


### PR DESCRIPTION
What I did:
- Implemented lldpRemManAddrTable & lldpLocManAddrTable

Also requires https://github.com/Azure/sonic-snmpagent/pull/72

**lldpRemManAddrTable**

OID | SNMP counter | Description
-- | -- | --
1.0.8802.1.1.2.1.4.2.1.1 | lldpRemManAddrSubtype | The type of management address identifier encoding used in the associated 'lldpRemManagmentAddr' object
1.0.8802.1.1.2.1.4.2.1.2 | lldpRemManAddr | The string value used to identify the management address component associated with the remote system. The purpose of this address is to contact the management entity
1.0.8802.1.1.2.1.4.2.1.3 | lldpRemManAddrIfSubtype | The enumeration value that identifies the interface numbering method used for defining the interface number, associated with the remote system
1.0.8802.1.1.2.1.4.2.1.4 | lldpRemManAddrIfId | The integer value used to identify the interface number regarding the management address component associated with the remote system
1.0.8802.1.1.2.1.4.2.1.5 | lldpRemManAddrOID | The OID value used to identify the type of hardware component or protocol entity associated with the management address advertised by the remote system agent

**lldpLocManAddrTable**

OID | SNMP counter | Description
-- | -- | --
1.0.8802.1.1.2.1.3.8.1.1 | lldpLocManAddrSubtype | The type of management address identifier encoding used in the associated 'lldpLocManagmentAddr' object
1.0.8802.1.1.2.1.3.8.1.2 | lldpLocManAddr | The string value used to identify the management address component associated with the local system. The purpose of this address is to contact the management entity.
1.0.8802.1.1.2.1.3.8.1.3 | lldpLocManAddrLen | The total length of the management address subtype and the management address fields in LLDPDUs transmitted by the local LLDP agent.
1.0.8802.1.1.2.1.3.8.1.4 | lldpLocManAddrIfSubtype | The enumeration value that identifies the interface numbering method used for defining the interface number, associated with the local system
1.0.8802.1.1.2.1.3.8.1.5 | lldpLocManAddrIfId | The integer value used to identify the interface number regarding the management address component associated with the local system.
1.0.8802.1.1.2.1.3.8.1.6 | lldpLocManAddrOID | The OID value used to identify the type of hardware component or protocol entity associated with the management address advertised by the local system agent.

