### PR TITLE
[lldp_syncd] fix call to lldpd setting configurable port description

### DIFF
--- a/src/lldp_syncd/dbsyncd.py
+++ b/src/lldp_syncd/dbsyncd.py
@@ -40,7 +40,7 @@ class DBSyncDaemon(SonicSyncDaemon):
             new_descr = data.get("description", " ")
             logger.info("[lldp dbsyncd] Port {} description changed to {}."
                         .format(key, new_descr))
-            self.run_command("lldpcli configure lldp portidsubtype local {} description '{}'"
+            self.run_command("lldpcli configure ports {0} lldp portidsubtype local {0} description '{1}'"
                              .format(key, new_descr))
         # update local cache
         self.port_table[key] = data
@@ -64,7 +64,7 @@ class DBSyncDaemon(SonicSyncDaemon):
         self.port_table = self.config_db.get_table(PORT_TABLE_NAME)
         # supply LLDP_LOC_ENTRY_TABLE and lldpd with correct values on start
         for port_name, attributes in self.port_table.items():
-            self.run_command("lldpcli configure lldp portidsubtype local {} description '{}'"
+            self.run_command("lldpcli configure ports {0} lldp portidsubtype local {0} description '{1}'"
                              .format(port_name, attributes.get("description", " ")))
 
     def run(self):

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -104,7 +104,7 @@ class TestLldpSyncDaemonDBSync(TestCase):
         with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
             self.daemon.port_handler("Ethernet4", {"description": "black door", "speed": '50000'})
             self.daemon.run_command.assert_called_once_with(
-                "lldpcli configure lldp portidsubtype local Ethernet4 description 'black door'")
+                "lldpcli configure ports Ethernet4 lldp portidsubtype local Ethernet4 description 'black door'")
 
     def test_port_handler_speed(self):
         """
@@ -121,7 +121,7 @@ class TestLldpSyncDaemonDBSync(TestCase):
         with mock.patch.object(lldp_syncd.DBSyncDaemon, "run_command", mock.Mock()):
             self.daemon.port_handler("Ethernet4", {"speed": '50000'})
             self.daemon.run_command.assert_called_once_with(
-                "lldpcli configure lldp portidsubtype local Ethernet4 description ' '")
+               "lldpcli configure ports Ethernet4 lldp portidsubtype local Ethernet4 description ' '") 
 
     def test_man_addr_init(self):
 


### PR DESCRIPTION
Take care of issue when port description configured by user was not advertised by LLDP correctly.