### PR TITLE
avoid exception when local-chassis information is missing

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -341,14 +341,15 @@ class LldpSyncDaemon(SonicSyncDaemon):
         logger.debug("Initiating LLDPd sync to Redis...")
 
         # push local chassis data to APP DB
-        chassis_update = parsed_update.pop('local-chassis')
-        if chassis_update != self.chassis_cache:
-            self.db_connector.delete(self.db_connector.APPL_DB,
-                                     LldpSyncDaemon.LLDP_LOC_CHASSIS_TABLE)
-            for k, v in chassis_update.items():
-                self.db_connector.set(self.db_connector.APPL_DB,
-                                      LldpSyncDaemon.LLDP_LOC_CHASSIS_TABLE, k, v, blocking=True)
-            logger.debug("sync'd: {}".format(json.dumps(chassis_update, indent=3)))
+        if parsed_update.has_key('local-chassis'):
+            chassis_update = parsed_update.pop('local-chassis')
+            if chassis_update != self.chassis_cache:
+                self.db_connector.delete(self.db_connector.APPL_DB,
+                                         LldpSyncDaemon.LLDP_LOC_CHASSIS_TABLE)
+                for k, v in chassis_update.items():
+                    self.db_connector.set(self.db_connector.APPL_DB,
+                                          LldpSyncDaemon.LLDP_LOC_CHASSIS_TABLE, k, v, blocking=True)
+                logger.debug("sync'd: {}".format(json.dumps(chassis_update, indent=3)))
 
         new, changed, deleted = self.cache_diff(self.interfaces_cache, parsed_update)
         # Delete LLDP_ENTRIES which were modified or are missing


### PR DESCRIPTION
We are seeing the following exception that causes lldp-syncd to stop proper functioning.

```
Sep 25 18:58:24.741727 sonic-7 INFO lldp#lldp-syncd [lldp_syncd] INFO: Starting SONiC LLDP sync daemon...
Sep 25 18:58:24.747158 sonic-7 INFO lldp#lldp-syncd [lldp_syncd] INFO: [lldp dbsyncd] Connected to configdb
Sep 25 18:58:24.807744 sonic-7 INFO lldp#supervisord: lldp-syncd Exception in thread LldpSyncDaemon:
Sep 25 18:58:24.807994 sonic-7 INFO lldp#supervisord: lldp-syncd Traceback (most recent call last):
Sep 25 18:58:24.808174 sonic-7 INFO lldp#supervisord: lldp-syncd   File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
Sep 25 18:58:24.808443 sonic-7 INFO lldp#supervisord: lldp-syncd     self.run()
Sep 25 18:58:24.808602 sonic-7 INFO lldp#supervisord: lldp-syncd   File "/usr/local/lib/python2.7/dist-packages/sonic_syncd/interface.py", line 47, in run
Sep 25 18:58:24.808763 sonic-7 INFO lldp#supervisord: lldp-syncd     self.sync(parsed_update)
Sep 25 18:58:24.808929 sonic-7 INFO lldp#supervisord: lldp-syncd   File "/usr/local/lib/python2.7/dist-packages/lldp_syncd/daemon.py", line 344, in sync
Sep 25 18:58:24.809200 sonic-7 INFO lldp#supervisord: lldp-syncd     chassis_update = parsed_update.pop('local-chassis')
Sep 25 18:58:24.809502 sonic-7 INFO lldp#supervisord: lldp-syncd KeyError: 'local-chassis'
```

This PR will fix this bug. However, we should continue to dig deeper why `local-chassis` key is missing from `parsed_update`. 