### PR TITLE
[lldp_syncd] fix LLDP_LOC_CHASSIS not push to APPL DB

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -255,30 +255,6 @@ class LldpSyncDaemon(SonicSyncDaemon):
                 parsed_interfaces[if_name].update({'lldp_rem_sys_cap_enabled':
                                                    self.parse_sys_capabilities(
                                                        capability_list, enabled=True)})
-                if lldp_json['lldp_loc_chassis']:
-                    loc_chassis_keys = ('lldp_loc_chassis_id_subtype',
-                                        'lldp_loc_chassis_id',
-                                        'lldp_loc_sys_name',
-                                        'lldp_loc_sys_desc',
-                                        'lldp_loc_man_addr')
-                    parsed_chassis = dict(zip(loc_chassis_keys,
-                                         self.parse_chassis(lldp_json['lldp_loc_chassis']
-                                                            ['local-chassis']['chassis'])))
-
-                    loc_capabilities = self.get_sys_capability_list(lldp_json['lldp_loc_chassis']
-                                                                    ['local-chassis'])
-                    # lldpLocSysCapSupported
-                    parsed_chassis.update({'lldp_loc_sys_cap_supported':
-                                          self.parse_sys_capabilities(loc_capabilities)})
-                    # lldpLocSysCapEnabled
-                    parsed_chassis.update({'lldp_loc_sys_cap_enabled':
-                                          self.parse_sys_capabilities(loc_capabilities, enabled=True)})
-
-                    parsed_interfaces['local-chassis'].update(parsed_chassis)
-
-            if len(interface_list) :
-                return parsed_interfaces
-
             if lldp_json['lldp_loc_chassis']:
                 loc_chassis_keys = ('lldp_loc_chassis_id_subtype',
                                     'lldp_loc_chassis_id',

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -276,7 +276,32 @@ class LldpSyncDaemon(SonicSyncDaemon):
 
                     parsed_interfaces['local-chassis'].update(parsed_chassis)
 
+            if len(interface_list) :
+                return parsed_interfaces
+
+            if lldp_json['lldp_loc_chassis']:
+                loc_chassis_keys = ('lldp_loc_chassis_id_subtype',
+                                    'lldp_loc_chassis_id',
+                                    'lldp_loc_sys_name',
+                                    'lldp_loc_sys_desc',
+                                    'lldp_loc_man_addr')
+                parsed_chassis = dict(zip(loc_chassis_keys,
+                                     self.parse_chassis(lldp_json['lldp_loc_chassis']
+                                                        ['local-chassis']['chassis'])))
+
+                loc_capabilities = self.get_sys_capability_list(lldp_json['lldp_loc_chassis']
+                                                                ['local-chassis'])
+                # lldpLocSysCapSupported
+                parsed_chassis.update({'lldp_loc_sys_cap_supported':
+                                      self.parse_sys_capabilities(loc_capabilities)})
+                # lldpLocSysCapEnabled
+                parsed_chassis.update({'lldp_loc_sys_cap_enabled':
+                                      self.parse_sys_capabilities(loc_capabilities, enabled=True)})
+
+                parsed_interfaces['local-chassis'].update(parsed_chassis)
+
             return parsed_interfaces
+
         except (KeyError, ValueError):
             logger.exception("Failed to parse LLDPd JSON. \n{}\n -- ".format(lldp_json))
 


### PR DESCRIPTION
Signed-off-by: chenhu <chenhu@didiglobal.com>

while startup the json file is like below, current parse_update not process the json correctly, just return defaultdict(dict)

<pre>
{
        'lldp': {}, 
        'lldp_loc_chassis': {
            'local-chassis': {
                'chassis': {
                    'S9130-Core': {
                        'capability': [
                            {'enabled': True, 'type': 'Bridge'}, 
                            {'enabled': True, 'type': 'Router'}, 
                            {'enabled': False, 'type': 'Wlan'}, 
                            {'enabled': False, 'type': 'Station'}
                        ], 
                        'mgmt-ip': '172.25.5.43', 
                        'id': {
                            'type': 'local', 
                            'value': 'S9130-Core'
                        }, 
                        'descr': 'Debian GNU/Linux 8 (jessie) Linux 3.16.0-5-amd64 #1 SMP Debian 3.16.51-3+deb8u1 (2018-01-08) x86_64',
                        'ttl': '120'
                    }
                }
            }
        }
    }
</pre>