### PR TITLE
Support multiple IP addresses for lldp_loc_man_addr

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -295,9 +295,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
             descr = attributes.get('descr', '')
             mgmt_ip = attributes.get('mgmt-ip', '')
             if isinstance(mgmt_ip, list):
-                mgmt_ip = ','.join(mgmt_ip).encode('utf-8')
-            else:
-                mgmt_ip = mgmt_ip.encode('utf-8')
+                mgmt_ip = ','.join(mgmt_ip)
         except (KeyError, ValueError):
             logger.exception("Could not infer system information from: {}"
                              .format(chassis_attributes))

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -295,7 +295,9 @@ class LldpSyncDaemon(SonicSyncDaemon):
             descr = attributes.get('descr', '')
             mgmt_ip = attributes.get('mgmt-ip', '')
             if isinstance(mgmt_ip, list):
-                mgmt_ip = [tmp_mgmt_ip.encode('utf-8') for tmp_mgmt_ip in mgmt_ip]
+                mgmt_ip = ','.join(mgmt_ip).encode('utf-8')
+            else:
+                mgmt_ip = mgmt_ip.encode('utf-8')
         except (KeyError, ValueError):
             logger.exception("Could not infer system information from: {}"
                              .format(chassis_attributes))

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -294,6 +294,8 @@ class LldpSyncDaemon(SonicSyncDaemon):
             chassis_id = id_attributes.get('value', '')
             descr = attributes.get('descr', '')
             mgmt_ip = attributes.get('mgmt-ip', '')
+            if isinstance(mgmt_ip, list):
+                mgmt_ip = [tmp_mgmt_ip.encode('utf-8') for tmp_mgmt_ip in mgmt_ip]
         except (KeyError, ValueError):
             logger.exception("Could not infer system information from: {}"
                              .format(chassis_attributes))


### PR DESCRIPTION
**What I did**
Fix the issue https://github.com/Azure/sonic-snmpagent/issues/104

**Why I did it**
DUT can't get lldpLocManAddr mib node via SNMP

**How I did it**
Shall use ',' to separate multiple mgmt_ip and write string to redis database.

**How I verified it**
> 
	127.0.0.1:6379> hgetall "LLDP_LOC_CHASSIS"
	 1) "lldp_loc_sys_cap_supported"
	 2) "28 00"
	 3) "lldp_loc_sys_cap_enabled"
	 4) "28 00"
	 5) "lldp_loc_sys_name"
	 6) "sonic"
	 7) "lldp_loc_sys_desc"
	 8) "Debian GNU/Linux 8 (jessie) Linux 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64"
	 9) "lldp_loc_chassis_id_subtype"
	10) "4"
	11) "lldp_loc_man_addr"
	12) "10.1.0.1,fe80::ce37:abff:feec:de9c"
	13) "lldp_loc_chassis_id"
	14) "cc:37:ab:ec:de:9c"
	127.0.0.1:6379>

> 	
	>snmpwalk -v2c -c public 192.168.1.100 1.0.8802.1.1.2.1.3.8
	iso.0.8802.1.1.2.1.3.8.1.1.1.4.10.1.0.1 = INTEGER: 1
	iso.0.8802.1.1.2.1.3.8.1.2.1.4.10.1.0.1 = STRING: "0A 01 00 01"
	iso.0.8802.1.1.2.1.3.8.1.3.1.4.10.1.0.1 = INTEGER: 5
	iso.0.8802.1.1.2.1.3.8.1.4.1.4.10.1.0.1 = INTEGER: 2
	iso.0.8802.1.1.2.1.3.8.1.5.1.4.10.1.0.1 = INTEGER: 0
	iso.0.8802.1.1.2.1.3.8.1.6.1.4.10.1.0.1 = OID: iso.3.6.1.2.1.2.2.1.1



Signed-off-by: Emma Lin kelly_chen@edge-core.com


