### PR TITLE
Add test case for local IP addresses parsing.

### DIFF
--- a/tests/mock_tables/LLDP_ENTRY_TABLE.json
+++ b/tests/mock_tables/LLDP_ENTRY_TABLE.json
@@ -460,5 +460,14 @@
     "lldp_rem_sys_name": "switch13",
     "lldp_rem_port_id": "Ethernet4",
     "lldp_rem_man_addr": "10.3.147.196"
+  },
+  "LLDP_LOC_CHASSIS": {
+    "lldp_loc_chassis_id_subtype": "4",
+    "lldp_loc_chassis_id": "7c:fe:90:63:f4:66",
+    "lldp_loc_sys_name": "arc-switch1025",
+    "lldp_loc_sys_desc": "Debian GNU/Linux 8 (jessie) Linux 3.16.0-5-amd64 #1 SMP Debian 3.16.51-3+deb8u1 (2018-01-08) x86_64",
+    "lldp_loc_man_addr": "10.1.0.32,fc00:1::32",
+    "lldp_loc_sys_cap_supported": "28 00",
+    "lldp_loc_sys_cap_enabled": "28 00"
   }
 }

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -66,7 +66,10 @@ class TestLldpSyncDaemon(TestCase):
 
         dump = {}
         for k in keys:
-            dump[k] = db.get_all(db.APPL_DB, k)
+            # The test case id for LLDP neighbor information.
+            # Need to filer LLDP_LOC_CHASSIS entry because the entry is removed from parsed_update after executing daemon.sync().
+            if k != 'LLDP_LOC_CHASSIS':
+                dump[k] = db.get_all(db.APPL_DB, k)
         print(json.dumps(dump, indent=3))
 
         # convert dict keys to ints for easy comparison
@@ -101,3 +104,11 @@ class TestLldpSyncDaemon(TestCase):
                 i+=1
         else:
             self.assertEquals(mgmt_ip, json_mgmt_ip)
+
+    def test_loc_chassis(self):
+        parsed_update = self.daemon.parse_update(self._json)
+        parsed_loc_chassis = parsed_update['local-chassis']
+        self.daemon.sync(parsed_update)
+        db = create_dbconnector()
+        db_loc_chassis_data = db.get_all(db.APPL_DB, 'LLDP_LOC_CHASSIS')
+        self.assertEquals(parsed_loc_chassis, db_loc_chassis_data)

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -66,7 +66,7 @@ class TestLldpSyncDaemon(TestCase):
 
         dump = {}
         for k in keys:
-            # The test case id for LLDP neighbor information.
+            # The test case is for LLDP neighbor information.
             # Need to filer LLDP_LOC_CHASSIS entry because the entry is removed from parsed_update after executing daemon.sync().
             if k != 'LLDP_LOC_CHASSIS':
                 dump[k] = db.get_all(db.APPL_DB, k)

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -87,3 +87,17 @@ class TestLldpSyncDaemon(TestCase):
     def test_timeparse(self):
         self.assertEquals(lldp_syncd.daemon.parse_time("0 day, 05:09:02"), make_seconds(0, 5, 9, 2))
         self.assertEquals(lldp_syncd.daemon.parse_time("2 days, 05:59:02"), make_seconds(2, 5, 59, 2))
+
+    def test_parse_mgmt_ip(self):
+        parsed_update = self.daemon.parse_update(self._json)
+        mgmt_ip_str = parsed_update['local-chassis'].get('lldp_loc_man_addr')
+        json_chassis = json.dumps(self._json['lldp_loc_chassis']['local-chassis']['chassis'])
+        chassis_dict = json.loads(json_chassis)
+        json_mgmt_ip = chassis_dict.values()[0]['mgmt-ip']
+        if isinstance(json_mgmt_ip, list):
+            i=0
+            for mgmt_ip in mgmt_ip_str.split(','):
+                self.assertEquals(mgmt_ip, json_mgmt_ip[i])
+                i+=1
+        else:
+            self.assertEquals(mgmt_ip, json_mgmt_ip)

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -67,7 +67,7 @@ class TestLldpSyncDaemon(TestCase):
         dump = {}
         for k in keys:
             # The test case is for LLDP neighbor information.
-            # Need to filer LLDP_LOC_CHASSIS entry because the entry is removed from parsed_update after executing daemon.sync().
+            # Need to filter LLDP_LOC_CHASSIS entry because the entry is removed from parsed_update after executing daemon.sync().
             if k != 'LLDP_LOC_CHASSIS':
                 dump[k] = db.get_all(db.APPL_DB, k)
         print(json.dumps(dump, indent=3))


### PR DESCRIPTION
**What I did**
Add a test case for local IP addresses parsing.
**How I verified it**
Add test cases in test_lldpSyncDaemon.py to make sure the test result is correct.
the result is shown below

> 
	/sonic-dbsyncd$ pytest -v
	================================================= test session starts ==================================================
	platform linux2 -- Python 2.7.15rc1, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python2
	cachedir: .cache
	rootdir: /mnt/d/lldp_syncd/sonic-dbsyncd, inifile:
	collected 6 items

	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_json PASSED                                         [ 16%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_mgmt_ip PASSED                                      [ 33%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short PASSED                                        [ 50%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short_short PASSED                                  [ 66%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_sync_roundtrip PASSED                                     [ 83%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_timeparse PASSED                                          [100%]

**Details if related**