### PR TITLE
Fix issue#14 lldp-syncd throws exception from get_sys_capability_list

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -118,7 +118,10 @@ class LldpSyncDaemon(SonicSyncDaemon):
         """
         try:
             # [{'enabled': ..., 'type': 'capability1'}, {'enabled': ..., 'type': 'capability2'}]
-            capability_list = if_attributes['chassis'].values()[0]['capability']
+            if 'capability' in if_attributes['chassis']:
+                capability_list = if_attributes['chassis']['capability']
+            else:
+                capability_list = if_attributes['chassis'].values()[0]['capability']
             # {'enabled': ..., 'type': 'capability'}
             if isinstance(capability_list, dict):
                 capability_list = [capability_list]

--- a/tests/subproc_outputs/interface_only.json
+++ b/tests/subproc_outputs/interface_only.json
@@ -1,0 +1,82 @@
+{
+  "lldp": {
+    "interface": [
+      {
+        "Ethernet0": {
+          "rid": "1",
+          "port": {
+            "id": {
+              "type": "ifname",
+              "value": "Ethernet1"
+            },
+            "mfs": "9236"
+          },
+          "via": "LLDP",
+          "chassis": {
+            "mgmt-ip": "10.3.147.196",
+            "id": {
+              "type": "mac",
+              "value": "00:11:22:33:44:55"
+            },
+            "ttl": "120",
+            "descr": "I'm a little teapot.",
+            "capability": [
+              {
+                "type": "Bridge",
+                "enabled": true
+              },
+              {
+                "type": "Router",
+                "enabled": true
+              }
+            ]
+          },
+          "age": "0 day, 05:09:05",
+          "vlan": {
+            "vlan-id": "101",
+            "pvid": true
+          }
+        }
+      },
+      {
+        "Ethernet100": {
+          "rid": "1",
+          "port": {
+            "id": {
+              "type": "ifname",
+              "value": "Ethernet26"
+            },
+            "mfs": "9236"
+          },
+          "via": "LLDP",
+          "chassis": {
+            "switch13": {
+              "mgmt-ip": "10.3.147.196",
+              "id": {
+                "type": "mac",
+                "value": "00:11:22:33:44:55"
+              },
+              "ttl": "120",
+              "descr": "I'm a little teapot.",
+              "capability": [
+                {
+                  "type": "Bridge",
+                  "enabled": true
+                },
+                {
+                  "type": "Router",
+                  "enabled": true
+                }
+              ]
+            }
+          },
+          "age": "0 day, 05:09:04",
+          "vlan": {
+            "vlan-id": "126",
+            "pvid": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/subproc_outputs/interface_only.json
+++ b/tests/subproc_outputs/interface_only.json
@@ -32,10 +32,12 @@
             ]
           },
           "age": "0 day, 05:09:05",
-          "vlan": {
-            "vlan-id": "101",
-            "pvid": true
-          }
+          "vlan": [
+            {
+              "vlan-id": "101",
+              "pvid": true
+            }
+          ]
         }
       },
       {
@@ -71,10 +73,12 @@
             }
           },
           "age": "0 day, 05:09:04",
-          "vlan": {
-            "vlan-id": "126",
-            "pvid": true
-          }
+          "vlan": [
+            {
+              "vlan-id": "126",
+              "pvid": true
+            }
+          ]
         }
       }
     ]

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -47,6 +47,9 @@ class TestLldpSyncDaemon(TestCase):
         with open(os.path.join(INPUT_DIR, 'lldpctl_single_loc_mgmt_ip.json')) as f:
             self._single_loc_mgmt_ip = json.load(f)
 
+        with open(os.path.join(INPUT_DIR, 'interface_only.json')) as f:
+            self._interface_only = json.load(f)
+
         self.daemon = lldp_syncd.LldpSyncDaemon()
 
     def test_parse_json(self):
@@ -121,3 +124,10 @@ class TestLldpSyncDaemon(TestCase):
         db = create_dbconnector()
         db_loc_chassis_data = db.get_all(db.APPL_DB, 'LLDP_LOC_CHASSIS')
         self.assertEquals(parsed_loc_chassis, db_loc_chassis_data)
+
+    def test_remote_sys_capability_list(self):
+        interface_list = self._interface_only['lldp'].get('interface')
+        for interface in interface_list:
+            (if_name, if_attributes), = interface.items()
+            capability_list = self.daemon.get_sys_capability_list(if_attributes)
+            self.assertNotEqual(capability_list, [])


### PR DESCRIPTION
**What I did**
To fix issue https://github.com/Azure/sonic-dbsyncd/issues/14 and add test cases to parse sys_capability_list for remote devices.

**Why I did it**
Current get_sys_capability_list don't consider the system name of remote device is null case.
If devices don't configure host name, it will send out LLDPPDU whose System Name TLV is null string.
When sonic device learned the remote device, the chassis object of lldp_json does not include system name string.
The capability_list does not get successfully by applying current statement, capability_list = if_attributes['chassis'].values()[0]['capability'].
We can execute lldpctl command to see the difference.
root@sonic:~# docker exec -it lldp bash
root@sonic:/# /usr/sbin/lldpctl -f json
[Remote device without system name]
> 
        "chassis": {
          ...
          "capability": [
            {
              "type": "Bridge",
              "enabled": true
            },
            {
              "type": "Router",
              "enabled": true
            }
          ]
        }
[Remote device with system name]
> 
        "chassis": {
          "system_name": {
            ......
            "capability": [
              {
                "type": "Bridge",
                "enabled": true
              },
              {
                "type": "Router",
                "enabled": true
              }
            ]
          }
        }
**How I verified it**
Add test case.
> 
	sonic-dbsyncd$ pytest -v
	================================================= test session starts ==================================================
	platform linux2 -- Python 2.7.15rc1, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python2
	cachedir: .cache
	rootdir: /mnt/d/lldp_syncd/sonic-dbsyncd, inifile:
	collected 9 items

	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_loc_chassis PASSED                                        [ 11%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_multiple_mgmt_ip PASSED                                   [ 22%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_json PASSED                                         [ 33%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short PASSED                                        [ 44%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short_short PASSED                                  [ 55%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_remote_sys_capability_list PASSED                         [ 66%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_single_mgmt_ip PASSED                                     [ 77%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_sync_roundtrip PASSED                                     [ 88%]
	tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_timeparse PASSED                                          [100%]


Signed-off-by: kelly_chen <kelly_chen@edge-core.com>