### PR TITLE
To correct vlan format in testing json files.

### DIFF
--- a/tests/subproc_outputs/interface_only.json
+++ b/tests/subproc_outputs/interface_only.json
@@ -36,6 +36,10 @@
             {
               "vlan-id": "101",
               "pvid": true
+            },
+            {
+              "vlan-id": "201",
+              "value": "vlan201"
             }
           ]
         }
@@ -73,12 +77,10 @@
             }
           },
           "age": "0 day, 05:09:04",
-          "vlan": [
-            {
-              "vlan-id": "126",
-              "pvid": true
-            }
-          ]
+          "vlan": {
+            "vlan-id": "126",
+            "pvid": true
+          }
         }
       }
     ]

--- a/tests/subproc_outputs/lldpctl.json
+++ b/tests/subproc_outputs/lldpctl.json
@@ -161,10 +161,16 @@
             }
           },
           "age": "0 day, 05:09:05",
-          "vlan": {
-            "vlan-id": "101",
-            "pvid": true
-          }
+          "vlan": [
+            {
+              "vlan-id": "101",
+              "pvid": true
+            },
+            {
+              "vlan-id": "201",
+              "value": "vlan201"
+            }
+          ]
         }
       },
       {


### PR DESCRIPTION
**What I did**
To correct vlan format in testing json files.

**Why I did it**
It is possible that lldp neighbor has multiple VLANs.
To check json output format by executing lldpcli command, vlan shall be list format.

> 
    root@sonic:~# docker exec -it lldp bash
    root@sonic:/# /usr/sbin/lldpctl -f json
    {
      "lldp": {
        "interface": [
          {
            "Ethernet0": {
              "vlan": [
                {
                  "vlan-id": "1",
                  "pvid": true,
                  "value": "DefaultVlan"
                },
                {
                  "vlan-id": "2",
                  "value": "vlan2"
                }
              ],
              "rid": "2",
              "via": "LLDP",
              "port": {
                "id": {
                  "type": "mac",
                  "value": "80:22:07:33:65:1a"
                },
                "descr": "Ethernet Port on unit 1, port 25",
                "mfs": "1522",
                "auto-negotiation": {
                  "supported": true,
                  "enabled": true,
                  "current": "10GigBaseLR - R fiber over 1310 nm optics"
                }
              },
              "age": "0 day, 00:01:23",
              "chassis": {
                "id": {
                  "type": "mac",
                  "value": "80:22:07:33:65:01"
                },
                "ttl": "120",
                "descr": "ECS4120-28T",
                "capability": [
                  {
                    "type": "Bridge",
                    "enabled": true
                  },
                  {
                    "type": "Router",
                    "enabled": true
                  }
                ]
              },
              "ppvid": {
                "supported": true,
                "enabled": false
              },
              "pi": [
                "00 27 42 42 03 00 00 02",
                "88 09 01",
                "88 09 03",
                "88 8e",
                "89 02"
              ]
            }
          }
        ]
      }
    }

**How I verified it** 
Don't  impact test results. 

> 
    /sonic-dbsyncd$ pytest -v
    ================================================= test session starts ==================================================
    platform linux2 -- Python 2.7.15rc1, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python2
    cachedir: .cache
    rootdir: /mnt/d/lldp_syncd/sonic-dbsyncd, inifile:
    collected 8 items   

    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_loc_chassis PASSED                                        [ 12%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_multiple_mgmt_ip PASSED                                   [ 25%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_json PASSED                                         [ 37%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short PASSED                                        [ 50%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short_short PASSED                                  [ 62%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_single_mgmt_ip PASSED                                     [ 75%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_sync_roundtrip PASSED                                     [ 87%]
    tests/test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_timeparse PASSED                                          [100%] 

    =============================================== 8 passed in 0.25 seconds ===============================================