### PR TITLE
Negative LLDP time

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -43,9 +43,18 @@ def parse_time(time_str):
             return sage;
     }
     :return: parsed age in time ticks (or seconds)
+             0 in case passed in string has negative time
+             due to setting system clock backwards
     """
+    if '-' in time_str:
+        return 0 
+
     days, hour_min_secs = re.split(LLDPD_UPTIME_RE_SPLIT_PATTERN, time_str)
-    struct_time = time.strptime(hour_min_secs, LLDPD_TIME_FORMAT)
+    try:
+        struct_time = time.strptime(hour_min_secs, LLDPD_TIME_FORMAT)
+    except ValueError:
+        logger.warning("Incorrect time {}, did you change system time?".format(hour_min_secs))
+        return 0
     time_delta = datetime.timedelta(days=int(days), hours=struct_time.tm_hour,
                                     minutes=struct_time.tm_min,
                                     seconds=struct_time.tm_sec)


### PR DESCRIPTION
If the passed in time string is negative, return 0 as delta time in lldp_syncd daemon.
This can happen when the system time is set to backwards. 

If not handled the time.strptime() throws valueError exception