### PR TITLE
[lldp daemon] improve lldp daemon event when neighbor capability is not received

### DIFF
--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -129,5 +129,5 @@ class TestLldpSyncDaemon(TestCase):
         interface_list = self._interface_only['lldp'].get('interface')
         for interface in interface_list:
             (if_name, if_attributes), = interface.items()
-            capability_list = self.daemon.get_sys_capability_list(if_attributes)
+            capability_list = self.daemon.get_sys_capability_list(if_attributes, if_name, "fake_chassis_id")
             self.assertNotEqual(capability_list, [])


### PR DESCRIPTION
Fixes https://github.com/Azure/sonic-buildimage/issues/5912

improve lldp daemon event when neighbor capability is not received

- Lower the event from error to info.
- Report interface name and chassis ID.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>