### PR TITLE
Fix the LLDP_LOC_CHASSIS not getting populated if no remote neighbors are present

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ stages:
       displayName: 'Checkout code'
     - script: |
         echo Hello
+        mkdir -p $(System.DefaultWorkingDirectory)/target/python-wheels/
         # the following is copied from jenkins
         # set -ex
         # ## Build

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -264,26 +264,26 @@ class LldpSyncDaemon(SonicSyncDaemon):
                 parsed_interfaces[if_name].update({'lldp_rem_sys_cap_enabled':
                                                    self.parse_sys_capabilities(
                                                        capability_list, enabled=True)})
-                if lldp_json['lldp_loc_chassis']:
-                    loc_chassis_keys = ('lldp_loc_chassis_id_subtype',
-                                        'lldp_loc_chassis_id',
-                                        'lldp_loc_sys_name',
-                                        'lldp_loc_sys_desc',
-                                        'lldp_loc_man_addr')
-                    parsed_chassis = dict(zip(loc_chassis_keys,
-                                         self.parse_chassis(lldp_json['lldp_loc_chassis']
-                                                            ['local-chassis']['chassis'])))
+            if lldp_json['lldp_loc_chassis']:
+                loc_chassis_keys = ('lldp_loc_chassis_id_subtype',
+                                    'lldp_loc_chassis_id',
+                                    'lldp_loc_sys_name',
+                                    'lldp_loc_sys_desc',
+                                    'lldp_loc_man_addr')
+                parsed_chassis = dict(zip(loc_chassis_keys,
+                                     self.parse_chassis(lldp_json['lldp_loc_chassis']
+                                                        ['local-chassis']['chassis'])))
 
-                    loc_capabilities = self.get_sys_capability_list(lldp_json['lldp_loc_chassis']
-                                                                    ['local-chassis'], if_name, chassis_id)
-                    # lldpLocSysCapSupported
-                    parsed_chassis.update({'lldp_loc_sys_cap_supported':
-                                          self.parse_sys_capabilities(loc_capabilities)})
-                    # lldpLocSysCapEnabled
-                    parsed_chassis.update({'lldp_loc_sys_cap_enabled':
-                                          self.parse_sys_capabilities(loc_capabilities, enabled=True)})
+                loc_capabilities = self.get_sys_capability_list(lldp_json['lldp_loc_chassis']
+                                                                ['local-chassis'], 'local', 'chassis')
+                # lldpLocSysCapSupported
+                parsed_chassis.update({'lldp_loc_sys_cap_supported':
+                                      self.parse_sys_capabilities(loc_capabilities)})
+                # lldpLocSysCapEnabled
+                parsed_chassis.update({'lldp_loc_sys_cap_enabled':
+                                      self.parse_sys_capabilities(loc_capabilities, enabled=True)})
 
-                    parsed_interfaces['local-chassis'].update(parsed_chassis)
+                parsed_interfaces['local-chassis'].update(parsed_chassis)
 
             return parsed_interfaces
         except (KeyError, ValueError):

--- a/tests/subproc_outputs/lldpctl_no_neighbors_loc_mgmt_ip.json
+++ b/tests/subproc_outputs/lldpctl_no_neighbors_loc_mgmt_ip.json
@@ -1,0 +1,37 @@
+{
+  "lldp_loc_chassis":{
+    "local-chassis": {
+      "chassis": {
+        "arc-switch1025": {
+          "mgmt-ip": "10.1.0.32",
+          "id": {
+            "type": "mac",
+            "value": "7c:fe:90:63:f4:66"
+          },
+          "capability": [
+            {
+              "type": "Bridge",
+              "enabled": true
+            },
+            {
+              "type": "Router",
+              "enabled": true
+            },
+            {
+              "type": "Wlan",
+              "enabled": false
+            },
+            {
+              "type": "Station",
+              "enabled": false
+            }
+          ],
+          "descr": "Debian GNU/Linux 8 (jessie) Linux 3.16.0-5-amd64 #1 SMP Debian 3.16.51-3+deb8u1 (2018-01-08) x86_64",
+          "ttl": "120"
+        }
+      }
+    }
+  },
+  "lldp": {
+  }
+}

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -50,6 +50,9 @@ class TestLldpSyncDaemon(TestCase):
         with open(os.path.join(INPUT_DIR, 'interface_only.json')) as f:
             self._interface_only = json.load(f)
 
+        with open(os.path.join(INPUT_DIR, 'lldpctl_no_neighbors_loc_mgmt_ip.json')) as f:
+            self._no_neighbors_loc_mgmt_ip = json.load(f)
+
         self.daemon = lldp_syncd.LldpSyncDaemon()
 
     def test_parse_json(self):
@@ -115,6 +118,9 @@ class TestLldpSyncDaemon(TestCase):
 
     def test_single_mgmt_ip(self):
         self.parse_mgmt_ip(self._single_loc_mgmt_ip)
+
+    def test_local_mgmt_ip_no_neighbors(self):
+        self.parse_mgmt_ip(self._no_neighbors_loc_mgmt_ip)
 
     def test_loc_chassis(self):
         parsed_update = self.daemon.parse_update(self._json)


### PR DESCRIPTION
What I did:
Fixes the issue where `LLDP_LOC_CHASSIS` do not get populated if there are no remote neighbors.

Why I did:
@SuvarnaMeenakshi found issue when running `test_snmp_lldp.py` on multi-asic vs where on host lldp docker which only has 
`eth0` SNMP walk on locManAddress Tables was failing . This was because in VS we don't learn LLDP neighbors on `eth0`.

How I did:
`LLDP_LOC_CHASSIS` is local system information and should not depended on any remote info learnt. Removed it's update from the `interfaces for loop` to outside of it.

How I verify:

- Added unit test case that is failing without this change
- @SuvarnaMeenakshi verified SNMP walk is fine after this change.