### PR TITLE
Add to support the LLDP tlv without system capability

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -124,7 +124,13 @@ class LldpSyncDaemon(SonicSyncDaemon):
             if 'capability' in if_attributes['chassis']:
                 capability_list = if_attributes['chassis']['capability']
             else:
-                capability_list = list(if_attributes['chassis'].values())[0]['capability']
+                for attribute in if_attributes['chassis'].values():
+                    if 'capability' in attribute:
+                        capability_list = attribute['capability']
+                        break
+                else:
+                    capability_list = []
+
             # {'enabled': ..., 'type': 'capability'}
             if isinstance(capability_list, dict):
                 capability_list = [capability_list]

--- a/tests/subproc_outputs/interface_only.json
+++ b/tests/subproc_outputs/interface_only.json
@@ -45,6 +45,29 @@
         }
       },
       {
+        "Ethernet1": {
+          "via": "LLDP",
+          "rid": "8",
+          "age": "0 day, 00:00:01",
+          "chassis": {
+            "id": {
+              "type": "local",
+              "value": "55663150-3630-2543-4A30-323230424734"
+            },
+            "descr": "I'm a little teapot.",
+            "mgmt-ip": "0.0.0.0"
+          },
+          "port": {
+            "id": {
+              "type": "mac",
+              "value": "cc:12:33:44:55:66"
+            },
+            "descr": "PCI-E Slot 3, Port 1",
+            "ttl": "100"
+          }
+        }
+      },
+      {
         "Ethernet100": {
           "rid": "1",
           "port": {

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -135,4 +135,8 @@ class TestLldpSyncDaemon(TestCase):
         for interface in interface_list:
             (if_name, if_attributes), = interface.items()
             capability_list = self.daemon.get_sys_capability_list(if_attributes, if_name, "fake_chassis_id")
-            self.assertNotEqual(capability_list, [])
+            if if_name == 'Ethernet1':
+                self.assertEqual(capability_list, [])
+            else:
+                self.assertNotEqual(capability_list, [])
+


### PR DESCRIPTION
**What I did**
lldp-syncd will show error message while receiving LLDP frame without system capability attribute.
And cause the LLDP ENTRY is not be set to APP DB. Add to make daemon.py can handle this case

```
Apr 29 08:44:56.418954 as5812-54x-3 INFO lldp#lldp-syncd [lldp_syncd] INFO: Failed to get system capabilities on Ethernet1 (36383150-3630-5A43-5A30-32323042555)

127.0.0.1:6379> keys "*LLDP*"
1) "LLDP_ENTRY_TABLE:eth0"
2) "LLDP_LOC_CHASSIS"
3) "LLDP_ENTRY_TABLE:Ethernet31"
4) "LLDP_ENTRY_TABLE:Ethernet28"
5) "LLDP_ENTRY_TABLE:Ethernet30"
6) "LLDP_ENTRY_TABLE:Ethernet29"
127.0.0.1:6379> exit

```



**How I verified it**
```
ubuntu@f84f0d17fbb2:/sonic/src/sonic-dbsyncd/tests$ pytest-3 -v
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-dbsyncd, inifile: pytest.ini
plugins: cov-2.6.0
collected 10 items

test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_loc_chassis PASSED                                                                                                                                   [ 10%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_local_mgmt_ip_no_neighbors PASSED                                                                                                                    [ 20%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_multiple_mgmt_ip PASSED                                                                                                                              [ 30%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_json PASSED                                                                                                                                    [ 40%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short PASSED                                                                                                                                   [ 50%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_parse_short_short PASSED                                                                                                                             [ 60%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_remote_sys_capability_list PASSED                                                                                                                    [ 70%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_single_mgmt_ip PASSED                                                                                                                                [ 80%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_sync_roundtrip PASSED                                                                                                                                [ 90%]
test_lldpSyncDaemon.py::TestLldpSyncDaemon::test_timeparse PASSED                                                                                                                                     [100%]Coverage.py warning: Module src was never imported. (module-not-imported)
Coverage.py warning: No data was collected. (no-data-collected)
WARNING: Failed to generate report: No data to report.



-------------------------------------------------------------------- generated xml file: /sonic/src/sonic-dbsyncd/tests/test-results.xml --------------------------------------------------------------------

----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name    Stmts   Miss  Cover
---------------------------

============================================================================================= warnings summary ==============================================================================================
Failed to generate report: No data to report.

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================== 10 passed, 1 warnings in 0.21 seconds ===================================================================================
````

APP_DB
```
127.0.0.1:6379> keys "*LLDP*"
1) "LLDP_ENTRY_TABLE:eth0"
2) "LLDP_LOC_CHASSIS"
3) "LLDP_ENTRY_TABLE:Ethernet31"
4) "LLDP_ENTRY_TABLE:Ethernet28"
5) "LLDP_ENTRY_TABLE:Ethernet30"
6) "LLDP_ENTRY_TABLE:Ethernet1"
7) "LLDP_ENTRY_TABLE:Ethernet29"
127.0.0.1:6379> hgetall  "LLDP_ENTRY_TABLE:Ethernet1"
 1) "lldp_rem_port_id_subtype"
 2) "3"
 3) "lldp_rem_port_id"
 4) "cc:37:ab:5f:55:55"
 5) "lldp_rem_port_desc"
 6) "PCI-E Slot 2, Port 2"
 7) "lldp_rem_chassis_id_subtype"
 8) "7"
 9) "lldp_rem_chassis_id"
10) "36383150-3630-5A43-5A30-32323042555"
11) "lldp_rem_sys_name"
12) ""
13) "lldp_rem_sys_desc"
14) "ProLiant DL325 Gen10 Plus"
15) "lldp_rem_man_addr"
16) "0.0.0.0"
17) "lldp_rem_time_mark"
18) "23"
19) "lldp_rem_index"
20) "6"
21) "lldp_rem_sys_cap_supported"
22) ""
23) "lldp_rem_sys_cap_enabled"
24) ""
127.0.0.1:6379> exit
```