### PR TITLE
Fix issue of lldp_syncd crashes and cause docker lldp restarts

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -132,7 +132,7 @@ class LldpSyncDaemon(SonicSyncDaemon):
             # {'enabled': ..., 'type': 'capability'}
             if isinstance(capability_list, dict):
                 capability_list = [capability_list]
-        except KeyError:
+        except :
             logger.info("Failed to get system capabilities on {} ({})".format(if_name, chassis_id))
             return []
         return capability_list

--- a/tests/subproc_outputs/interface_only.json
+++ b/tests/subproc_outputs/interface_only.json
@@ -45,6 +45,26 @@
         }
       },
       {
+        "Ethernet47": {
+          "via": "LLDP",
+          "rid": "80",
+          "age": "0 day, 00:00:05",
+          "chassis": {
+            "id": {
+              "type": "mac",
+              "value": "e4:f4:c6:da:8d:d0"
+            }
+          },
+          "port": {
+            "id": {
+              "type": "ifname",
+              "value": "g5"
+            },
+            "ttl": "120"
+          }
+        }
+      },
+      {
         "Ethernet100": {
           "rid": "1",
           "port": {

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -137,7 +137,10 @@ class TestLldpSyncDaemon(TestCase):
         for interface in interface_list:
             (if_name, if_attributes), = interface.items()
             capability_list = self.daemon.get_sys_capability_list(if_attributes, if_name, "fake_chassis_id")
-            self.assertNotEqual(capability_list, [])
+            if if_name == 'Ethernet47':
+                self.assertEqual(capability_list, [])
+            else:
+                self.assertNotEqual(capability_list, [])
 
     def test_changed_deleted_interface(self):
         parsed_update = self.daemon.parse_update(self._json)


### PR DESCRIPTION
lldp-syncd throws exception from get_sys_capability_list The get_sys_capability_list() shall consider both the system name and system capabilities of remote device is null case.

Why I did it
During the usage process, we encountered the following issues.This has also led to the restart of the docker-lldp.
```
Nov 3 17:50:40.476595 sonic INFO lldp#supervisord: lldp-syncd capability_list = if_attributes['chassis'].values()[0]['capability']
Nov 3 17:50:40.476668 sonic INFO lldp#supervisord: lldp-syncd TypeError: string indices must be integers
```
