### PR TITLE
Fix lldp_syncd force-repopulate cascade on high-scale systems

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -392,31 +392,64 @@ class LldpSyncDaemon(SonicSyncDaemon):
         new, changed, deleted = self.cache_diff(self.interfaces_cache, parsed_update)
 
         # Always use incremental update for changed interfaces regardless of
-        # whether new or deleted interfaces exist. Previously, when new or deleted
-        # interfaces were detected, all changed interfaces were force-repopulated
-        # (delete+re-add), bypassing the is_only_time_mark_modified optimization.
-        # On high-scale systems (500+ ports), this caused a cascading repopulation
-        # storm during LLDP convergence, as new neighbors arriving each sync cycle
-        # triggered unnecessary force-repopulate of all existing entries.
+        # whether new or deleted interfaces exist in this sync cycle.
+        # Previously (PR #71), all changed interfaces were force-repopulated
+        # when new/deleted existed. On high-scale systems (500+ ports), this
+        # caused a cascading repopulation storm during LLDP convergence.
+        # Instead, we verify APPL_DB completeness per-interface: if APPL_DB
+        # was flushed externally (e.g. orchagent restart), the entry will be
+        # missing and we repopulate it. This handles both the APPL_DB flush
+        # scenario (PR #71) and prevents cascade on high-scale systems.
         for interface in changed:
             if re.match(SONIC_ETHERNET_RE_PATTERN, interface) is None:
                 logger.warning("Ignoring interface '{}'".format(interface))
                 continue
             table_key = ':'.join([LldpSyncDaemon.LLDP_ENTRY_TABLE, interface])
-            if self.is_only_time_mark_modified(self.interfaces_cache[interface], parsed_update[interface]):
-                self.db_connector.set(
+            if self.is_only_time_mark_modified(
+                    self.interfaces_cache[interface],
+                    parsed_update[interface]):
+                # Before using time_mark-only shortcut, verify APPL_DB has
+                # complete data. After external APPL_DB flush, cache still
+                # has full data so is_only_time_mark_modified returns True,
+                # but APPL_DB is empty — writing only time_mark would leave
+                # the entry incomplete (PR #71 scenario).
+                if self.db_connector.exists(
+                        self.db_connector.APPL_DB, table_key):
+                    existing = self.db_connector.get_all(
+                        self.db_connector.APPL_DB, table_key)
+                    if len(existing) > 1:
+                        self.db_connector.set(
+                            self.db_connector.APPL_DB, table_key,
+                            'lldp_rem_time_mark',
+                            parsed_update[interface]['lldp_rem_time_mark'],
+                            blocking=True)
+                        logger.debug(
+                            "Only sync'd interface {} "
+                            "lldp_rem_time_mark: {}".format(
+                                interface,
+                                parsed_update[interface][
+                                    'lldp_rem_time_mark']))
+                        continue
+                # APPL_DB missing or incomplete for this interface
+                if self.db_connector.exists(
+                        self.db_connector.APPL_DB, table_key):
+                    self.db_connector.delete(
+                        self.db_connector.APPL_DB, table_key)
+                self.db_connector.hmset(
                     self.db_connector.APPL_DB, table_key,
-                    'lldp_rem_time_mark',
-                    parsed_update[interface]['lldp_rem_time_mark'],
-                    blocking=True)
-                logger.debug(
-                    "Only sync'd interface {} lldp_rem_time_mark: {}"
-                    .format(interface,
-                            parsed_update[interface]['lldp_rem_time_mark']))
+                    parsed_update[interface])
+                logger.info(
+                    "Repopulate stale interface {} : {}".format(
+                        interface, parsed_update[interface]))
             else:
-                self.db_connector.delete(self.db_connector.APPL_DB, table_key)
-                self.db_connector.hmset(self.db_connector.APPL_DB, table_key, parsed_update[interface])
-                logger.info("Repopulate for changed interface {} : {}".format(interface, parsed_update[interface]))
+                self.db_connector.delete(
+                    self.db_connector.APPL_DB, table_key)
+                self.db_connector.hmset(
+                    self.db_connector.APPL_DB, table_key,
+                    parsed_update[interface])
+                logger.info(
+                    "Repopulate for changed interface {} : {}".format(
+                        interface, parsed_update[interface]))
         self.interfaces_cache = parsed_update
         # Delete LLDP_ENTRIES which are missing
         for interface in deleted:

--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -391,30 +391,32 @@ class LldpSyncDaemon(SonicSyncDaemon):
 
         new, changed, deleted = self.cache_diff(self.interfaces_cache, parsed_update)
 
-        if new or deleted:
-            # If detects any new or deleted interfaces, repopulate for changed interfaces
-            for interface in changed:
-                if re.match(SONIC_ETHERNET_RE_PATTERN, interface) is None:
-                    logger.warning("Ignoring interface '{}'".format(interface))
-                    continue
-                table_key = ':'.join([LldpSyncDaemon.LLDP_ENTRY_TABLE, interface])
+        # Always use incremental update for changed interfaces regardless of
+        # whether new or deleted interfaces exist. Previously, when new or deleted
+        # interfaces were detected, all changed interfaces were force-repopulated
+        # (delete+re-add), bypassing the is_only_time_mark_modified optimization.
+        # On high-scale systems (500+ ports), this caused a cascading repopulation
+        # storm during LLDP convergence, as new neighbors arriving each sync cycle
+        # triggered unnecessary force-repopulate of all existing entries.
+        for interface in changed:
+            if re.match(SONIC_ETHERNET_RE_PATTERN, interface) is None:
+                logger.warning("Ignoring interface '{}'".format(interface))
+                continue
+            table_key = ':'.join([LldpSyncDaemon.LLDP_ENTRY_TABLE, interface])
+            if self.is_only_time_mark_modified(self.interfaces_cache[interface], parsed_update[interface]):
+                self.db_connector.set(
+                    self.db_connector.APPL_DB, table_key,
+                    'lldp_rem_time_mark',
+                    parsed_update[interface]['lldp_rem_time_mark'],
+                    blocking=True)
+                logger.debug(
+                    "Only sync'd interface {} lldp_rem_time_mark: {}"
+                    .format(interface,
+                            parsed_update[interface]['lldp_rem_time_mark']))
+            else:
                 self.db_connector.delete(self.db_connector.APPL_DB, table_key)
                 self.db_connector.hmset(self.db_connector.APPL_DB, table_key, parsed_update[interface])
-                logger.info("Force repopulate the changed interface {} : {}".format(interface, parsed_update[interface]))
-        else:
-            # For changed elements, if only lldp_rem_time_mark changed, update its value, otherwise delete and repopulate
-            for interface in changed:
-                if re.match(SONIC_ETHERNET_RE_PATTERN, interface) is None:
-                    logger.warning("Ignoring interface '{}'".format(interface))
-                    continue
-                table_key = ':'.join([LldpSyncDaemon.LLDP_ENTRY_TABLE, interface])
-                if self.is_only_time_mark_modified(self.interfaces_cache[interface], parsed_update[interface]):
-                    self.db_connector.set(self.db_connector.APPL_DB, table_key, 'lldp_rem_time_mark', parsed_update[interface]['lldp_rem_time_mark'], blocking=True)
-                    logger.debug("Only sync'd interface {} lldp_rem_time_mark: {}".format(interface, parsed_update[interface]['lldp_rem_time_mark']))
-                else:
-                    self.db_connector.delete(self.db_connector.APPL_DB, table_key)
-                    self.db_connector.hmset(self.db_connector.APPL_DB, table_key, parsed_update[interface])
-                    logger.info("Repopulate for changed interface {} : {}".format(interface, parsed_update[interface]))
+                logger.info("Repopulate for changed interface {} : {}".format(interface, parsed_update[interface]))
         self.interfaces_cache = parsed_update
         # Delete LLDP_ENTRIES which are missing
         for interface in deleted:

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -143,7 +143,8 @@ class MockConnector(object):
         return key in MockConnector.data
 
     def set(self, db_id, key, field, value, blocking=False):
-        self.data[key] = {}
+        if key not in self.data:
+            self.data[key] = {}
         self.data[key][field] = value
 
     def hmset(self, db_id, key, fieldsvalues):

--- a/tests/test_lldpSyncDaemon.py
+++ b/tests/test_lldpSyncDaemon.py
@@ -298,3 +298,99 @@ class TestLldpSyncDaemon(TestCase):
             self.assertEqual(len(chassis_deletes), 0)
             self.assertEqual(len(chassis_sets), 0)
             self.assertEqual(self.daemon.chassis_cache, initial_cache)
+
+    def test_appl_db_flush_repopulates_changed_interfaces(self):
+        """
+        Regression test for PR #71 scenario: after APPL_DB is flushed externally
+        (e.g. orchagent restart), changed interfaces with only time_mark differences
+        must be fully repopulated, not just have time_mark updated.
+        """
+        # Step 1: Initial sync populates APPL_DB and cache
+        parsed_update = self.daemon.parse_update(self._json)
+        self.daemon.sync(parsed_update)
+        db = create_dbconnector()
+
+        # Verify eth0 has complete data
+        eth0_data = db.get_all(db.APPL_DB, TABLE_PREFIX + 'eth0')
+        self.assertIn('lldp_rem_chassis_id', eth0_data)
+        self.assertIn('lldp_rem_port_id', eth0_data)
+        self.assertGreater(len(eth0_data), 1)
+
+        # Step 2: Simulate APPL_DB flush (external event)
+        for key in list(db.data.keys()):
+            if key.startswith(TABLE_PREFIX):
+                del db.data[key]
+
+        # Step 3: Sync with only time_mark change on eth0
+        # Other interfaces removed to simulate them going down (deleted)
+        changed_json = self._json.copy()
+        changed_json['lldp']['interface'] = [
+            changed_json['lldp']['interface'][0]  # Keep only eth0
+        ]
+        changed_json['lldp']['interface'][0]['eth0']['age'] = '0 day, 05:09:12'
+
+        parsed_update = self.daemon.parse_update(changed_json)
+        self.daemon.sync(parsed_update)
+
+        # Step 4: Verify eth0 was fully repopulated, not just time_mark
+        self.assertTrue(db.exists(db.APPL_DB, TABLE_PREFIX + 'eth0'))
+        eth0_data = db.get_all(db.APPL_DB, TABLE_PREFIX + 'eth0')
+        self.assertIn('lldp_rem_chassis_id', eth0_data)
+        self.assertIn('lldp_rem_port_id', eth0_data)
+        self.assertIn('lldp_rem_time_mark', eth0_data)
+        self.assertGreater(len(eth0_data), 1,
+                           "eth0 should have complete data, not just time_mark")
+
+    def test_no_cascade_when_new_and_changed_coexist(self):
+        """
+        Regression test for issue #26568: when new interfaces arrive alongside
+        changed interfaces (time_mark only), the changed interfaces should NOT
+        be force-repopulated. Only time_mark should be updated.
+        """
+        # Step 1: Initial sync with subset of interfaces
+        initial_json = self._json.copy()
+        initial_json['lldp']['interface'] = [
+            initial_json['lldp']['interface'][0],  # eth0
+            initial_json['lldp']['interface'][1],  # Ethernet0
+        ]
+        parsed_update = self.daemon.parse_update(initial_json)
+        self.daemon.sync(parsed_update)
+        db = create_dbconnector()
+
+        # Record initial eth0 data
+        eth0_full = db.get_all(db.APPL_DB, TABLE_PREFIX + 'eth0')
+        eth0_time_mark = eth0_full['lldp_rem_time_mark']
+
+        # Step 2: Sync with eth0 time_mark changed + new interface added
+        changed_json = self._json.copy()
+        changed_json['lldp']['interface'][0]['eth0']['age'] = '0 day, 05:09:12'
+        # Ethernet0 unchanged time_mark, Ethernet100 and Ethernet104 are NEW
+
+        parsed_update = self.daemon.parse_update(changed_json)
+
+        # Track delete calls to detect force-repopulate of eth0
+        original_delete = self.daemon.db_connector.delete
+        deleted_keys = []
+
+        def tracking_delete(db_id, key):
+            deleted_keys.append(key)
+            return original_delete(db_id, key)
+
+        self.daemon.db_connector.delete = tracking_delete
+        self.daemon.sync(parsed_update)
+
+        # Step 3: Verify eth0 was NOT force-repopulated (no delete+hmset)
+        self.assertNotIn(TABLE_PREFIX + 'eth0', deleted_keys,
+                         "eth0 should not be deleted during convergence "
+                         "when only time_mark changed")
+
+        # Verify time_mark was updated
+        eth0_new = db.get_all(db.APPL_DB, TABLE_PREFIX + 'eth0')
+        self.assertNotEqual(eth0_new['lldp_rem_time_mark'], eth0_time_mark)
+        # Verify complete data still present
+        self.assertIn('lldp_rem_chassis_id', eth0_new)
+        self.assertIn('lldp_rem_port_id', eth0_new)
+
+        # Verify new interfaces were added
+        self.assertTrue(db.exists(db.APPL_DB, TABLE_PREFIX + 'Ethernet100'))
+        self.assertTrue(db.exists(db.APPL_DB, TABLE_PREFIX + 'Ethernet104'))


### PR DESCRIPTION
- Description:

Fix LLDP neighbor table instability on high-scale systems (500+ ports) while preserving APPL_DB flush recovery.

**Problem 1 (PR #71 scenario):** When APPL_DB is flushed externally (e.g. orchagent restart), lldp_syncd's in-memory cache still has full data. For interfaces like eth0 that stay up, is_only_time_mark_modified() returns True, so only lldp_rem_time_mark gets written - leaving APPL_DB incomplete.

**Problem 2 (issue #26568):** PR #71 fixed this by force-repopulating ALL changed interfaces when new or deleted interfaces exist. But on high-scale systems (SN5640, 512 ports) with VM topology, new neighbors arrive every 10s sync cycle during convergence. This triggers force-repopulate every cycle - cascading storm (3412+ force repopulates, 125 deletes, table never stabilizes).

**Root cause:** Using new or deleted as a proxy for APPL_DB might be stale is too broad - it fires every cycle during normal convergence.

- How to fix:

Instead of branching on new or deleted, verify APPL_DB completeness **per-interface** before using the time_mark-only shortcut:

1. exists() - check if APPL_DB has the entry
2. get_all() - check if it has more than just lldp_rem_time_mark (>1 field)
3. If complete - just update lldp_rem_time_mark (efficient, no churn)
4. If missing/incomplete - full delete + hmset (handles flush scenario)

This handles both scenarios:
- **APPL_DB flush:** entry missing - full repopulate
- **High-scale convergence:** entry complete - just time_mark - no cascade

Also fixes mock set() to properly emulate Redis HSET (update one field, not replace entire hash), and adds regression tests for both scenarios.

- Test:

**Verified on DUT str5-sn5640-6** (Mellanox SN5640, 512 ports, VM topology t0-isolated-d256u256s2):

| Metric | Before (PR #71 code) | After (this fix) |
|--------|---------------------|-------------------|
| delete_table | 125 | **0** |
| force_repopulate | 3412+ | **0** |
| Convergence | Never stable (oscillating 137-235) | Monotonic 0-108-118-145-160-202 (stable in 3.5 min) |

New unit tests:
- test_appl_db_flush_repopulates_changed_interfaces - PR #71 regression
- test_no_cascade_when_new_and_changed_coexist - issue #26568 regression

- Microsoft work item

30233240
