### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ steps:
     sudo dpkg -i libnl-genl-3-200_*.deb
     sudo dpkg -i libnl-route-3-200_*.deb
     sudo dpkg -i libnl-nf-3-200_*.deb
-    sudo dpkg -i libyang_1.*.deb
+    sudo dpkg -i libyang3_*.deb
     sudo dpkg -i libswsscommon_1.0.0_amd64.deb
     sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
   workingDirectory: $(Pipeline.Workspace)/target/debs/${{ parameters.dist }}/


### PR DESCRIPTION
#### Why I did it

`sonic-buildimage` no longer builds the legacy libyang1 packages (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`) — the build now produces only libyang3 (`libyang3`, `python3-libyang`). This repo's CI still `dpkg -i`'s the libyang1 deb, which will fail once libyang1 is gone.

Part of the libyang3 migration tracked in sonic-net/sonic-buildimage#22385.

#### How I did it

Updated the `azure-pipelines.yml` dependency install step to install the libyang3 deb using a versionless glob (`libyang3_*.deb`) instead of `libyang_1.*.deb`.

#### How to verify it

CI install step succeeds against the libyang3 debs produced by current `sonic-buildimage` master.

#### Description for the changelog

azure-pipelines: install libyang3 instead of libyang1.
